### PR TITLE
Remove upstream osv-offline

### DIFF
--- a/lib/workers/repository/process/types.ts
+++ b/lib/workers/repository/process/types.ts
@@ -1,4 +1,4 @@
-import type { Osv } from '@renovatebot/osv-offline';
+import type { Osv } from '@mintmaker/osv-offline';
 import type { RenovateConfig } from '../../../config/types';
 import type { PackageFile } from '../../../modules/manager/types';
 import type { VersioningApi } from '../../../modules/versioning';

--- a/lib/workers/repository/process/vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/vulnerabilities.spec.ts
@@ -1,4 +1,4 @@
-import type { Osv, OsvOffline } from '@renovatebot/osv-offline';
+import type { Osv, OsvOffline } from '@mintmaker/osv-offline';
 import { codeBlock } from 'common-tags';
 import { mockFn } from 'jest-mock-extended';
 import type { RenovateConfig } from '../../../../test/util';
@@ -11,7 +11,7 @@ const getVulnerabilitiesMock =
   mockFn<typeof OsvOffline.prototype.getVulnerabilities>();
 const createMock = jest.fn();
 
-jest.mock('@renovatebot/osv-offline', () => {
+jest.mock('@mintmaker/osv-offline', () => {
   return {
     __esModule: true,
     OsvOffline: class {

--- a/lib/workers/repository/process/vulnerabilities.ts
+++ b/lib/workers/repository/process/vulnerabilities.ts
@@ -1,6 +1,6 @@
 // TODO #22198
-import type { Ecosystem, Osv } from '@renovatebot/osv-offline';
-import { OsvOffline } from '@renovatebot/osv-offline';
+import type { Ecosystem, Osv } from '@mintmaker/osv-offline';
+import { OsvOffline } from '@mintmaker/osv-offline';
 import is from '@sindresorhus/is';
 import type { CvssScore } from 'vuln-vects';
 import { parseCvssVector } from 'vuln-vects';

--- a/package.json
+++ b/package.json
@@ -166,7 +166,6 @@
     "@qnighy/marshal": "0.1.3",
     "@renovatebot/detect-tools": "1.1.0",
     "@renovatebot/kbpgp": "4.0.1",
-    "@renovatebot/osv-offline": "1.5.12",
     "@mintmaker/osv-offline": "1.0.0",
     "@mintmaker/osv-offline-db": "1.0.0",
     "@renovatebot/pep440": "4.0.1",


### PR DESCRIPTION
This should be a safe change according to my testing. The downstream package is the same, so a few changed references should keep the same functionality.