### PR TITLE
Remove OSV reference in container vulnerabilities

### DIFF
--- a/lib/workers/repository/process/container-vulnerabilities.spec.ts
+++ b/lib/workers/repository/process/container-vulnerabilities.spec.ts
@@ -632,9 +632,7 @@ describe('workers/repository/process/container-vulnerabilities', () => {
               '- Vector String: `CVSS:3.1/AV:N/AC:H/PR:N/UI:N/S:U/C:H/I:H/A:H`\n' +
               '\n' +
               '#### References\n' +
-              'No references.\n' +
-              '\n' +
-              'This data is provided by [OSV](https://osv.dev/vulnerability/GHSA-22cc-w7xm-rfhx) and the [GitHub Advisory Database](https://github.com/github/advisory-database) ([CC-BY 4.0](https://github.com/github/advisory-database/blob/main/LICENSE.md)).\n' +
+              'No references.' +
               '</details>',
           ],
         },

--- a/lib/workers/repository/process/container-vulnerabilities.ts
+++ b/lib/workers/repository/process/container-vulnerabilities.ts
@@ -422,17 +422,6 @@ export class ContainerVulnerabilities {
         .join('\n') ?? 'No references.'
     }`;
 
-    let attribution = '';
-    if (vulnerability.id.startsWith('GHSA-')) {
-      attribution = ` and the [GitHub Advisory Database](https://github.com/github/advisory-database) ([CC-BY 4.0](https://github.com/github/advisory-database/blob/main/LICENSE.md))`;
-    } else if (vulnerability.id.startsWith('GO-')) {
-      attribution = ` and the [Go Vulnerability Database](https://github.com/golang/vulndb) ([CC-BY 4.0](https://github.com/golang/vulndb#license))`;
-    } else if (vulnerability.id.startsWith('PYSEC-')) {
-      attribution = ` and the [PyPI Advisory Database](https://github.com/pypa/advisory-database) ([CC-BY 4.0](https://github.com/pypa/advisory-database/blob/main/LICENSE))`;
-    } else if (vulnerability.id.startsWith('RUSTSEC-')) {
-      attribution = ` and the [Rust Advisory Database](https://github.com/RustSec/advisory-db) ([CC0 1.0](https://github.com/rustsec/advisory-db/blob/main/LICENSE.txt))`;
-    }
-    content += `\n\nThis data is provided by [OSV](https://osv.dev/vulnerability/${vulnerability.id})${attribution}.\n`;
     content += `</details>`;
 
     return [sanitizeMarkdown(content)];


### PR DESCRIPTION
Remove the sentence "This data is provided by OSV" for container vulnerabilities, since it's not true and the link is a 404 page.