### PR TITLE
Propagate ENV variables to rpm-lockfile-prototype

### DIFF
--- a/lib/modules/manager/rpm/extract.ts
+++ b/lib/modules/manager/rpm/extract.ts
@@ -23,6 +23,10 @@ async function getUpdatedLockfile(): Promise<void> {
 
   const execOptions: ExecOptions = {
     cwdFile: packageFileName,
+    extraEnv: {
+      DNF_VAR_SSL_CLIENT_KEY: process.env.DNF_VAR_SSL_CLIENT_KEY,
+      DNF_VAR_SSL_CLIENT_CERT: process.env.DNF_VAR_SSL_CLIENT_CERT,
+    },
   };
 
   try {


### PR DESCRIPTION
Renovate doesn't propagate environment variables to its child processes, which prevents the setup for subscription-only RPMs from working properly. Fix it by explicitly propagating the two new variables to dnf.

Refers to CLOUDDST-26090