### PR TITLE
Force the RPM lockfile rule to apply only to the root folder

### DIFF
--- a/lib/modules/manager/rpm/index.ts
+++ b/lib/modules/manager/rpm/index.ts
@@ -9,7 +9,7 @@ export const supportsLockFileMaintenance = true;
 export const supportedDatasources = [RPMLockfileDatasource.id];
 
 export const defaultConfig = {
-  fileMatch: ['(^|/)rpms\\.lock\\.ya?ml$'],
+  fileMatch: ['^rpms\\.lock\\.ya?ml$'],
 };
 
 export const categories: Category[] = ['rpm'];


### PR DESCRIPTION
Until now all found lockfiles were used to find dependencies, but since we generate a temporary lockfile as the datasource **only for root**, the manager would find updates only there and only this lockfile would be updated. However, this setup is leaving a lot of the behavior to chance, so I am changing the rule to only consider the root RPM lockfile for now, to enable consistent behavior.