### PR TITLE
Implement redis backend for repository cache

### DIFF
--- a/lib/util/cache/repository/impl/base.ts
+++ b/lib/util/cache/repository/impl/base.ts
@@ -99,6 +99,10 @@ export abstract class RepoCacheBase implements RepoCache {
     });
   }
 
+  cleanup(): Promise<void> {
+    return Promise.resolve();
+  }
+
   getData(): RepoCacheData {
     return this.data;
   }

--- a/lib/util/cache/repository/impl/cache-factory.ts
+++ b/lib/util/cache/repository/impl/cache-factory.ts
@@ -2,6 +2,7 @@ import type { RepositoryCacheType } from '../../../../config/types';
 import { logger } from '../../../../logger';
 import type { RepoCache } from '../types';
 import { RepoCacheLocal } from './local';
+import { RepoCacheRedis } from './redis';
 import { RepoCacheS3 } from './s3';
 
 export class CacheFactory {
@@ -11,17 +12,18 @@ export class CacheFactory {
     cacheType: RepositoryCacheType,
   ): RepoCache {
     const type = cacheType.split('://')[0].trim().toLowerCase();
-    switch (type) {
-      case 'local':
-        return new RepoCacheLocal(repository, repoFingerprint);
-      case 's3':
-        return new RepoCacheS3(repository, repoFingerprint, cacheType);
-      default:
-        logger.warn(
-          { cacheType },
-          `Repository cache type not supported using type "local" instead`,
-        );
-        return new RepoCacheLocal(repository, repoFingerprint);
+    if (type === 'local') {
+      return new RepoCacheLocal(repository, repoFingerprint);
+    } else if (type === 's3') {
+      return new RepoCacheS3(repository, repoFingerprint, cacheType);
+    } else if (type.includes('redis')) {
+      return new RepoCacheRedis(repository, repoFingerprint, cacheType);
+    } else {
+      logger.warn(
+        { cacheType },
+        `Repository cache type not supported using type "local" instead`,
+      );
+      return new RepoCacheLocal(repository, repoFingerprint);
     }
   }
 }

--- a/lib/util/cache/repository/impl/null.ts
+++ b/lib/util/cache/repository/impl/null.ts
@@ -13,6 +13,11 @@ export class RepoCacheNull implements RepoCache {
     return Promise.resolve();
   }
 
+  // istanbul ignore next
+  cleanup(): Promise<void> {
+    return Promise.resolve();
+  }
+
   getData(): RepoCacheData {
     return this.data;
   }

--- a/lib/util/cache/repository/impl/redis.spec.ts
+++ b/lib/util/cache/repository/impl/redis.spec.ts
@@ -1,0 +1,129 @@
+import type { RedisClientType } from 'redis';
+import { createClient } from 'redis';
+import { GlobalConfig } from '../../../../config/global';
+import { normalizeRedisUrl } from '../../package/redis';
+import type { RepoCacheRecord } from '../schema';
+import { RepoCacheRedis } from './redis';
+import { fs, partial } from '~test/util';
+
+vi.mock('redis');
+vi.mock('../../../fs');
+vi.mock('../../package/redis');
+
+describe('util/cache/repository/impl/redis', () => {
+  const repository = 'org/repo';
+  const fingerprint = '0123456789abcdef';
+  const repoCache = partial<RepoCacheRecord>({ payload: 'payload' });
+  const url = 'redis://localhost:6379';
+  const err = new Error('redis error');
+  let redisCache: RepoCacheRedis;
+
+  beforeEach(() => {
+    GlobalConfig.set({ cacheDir: '/tmp/cache', platform: 'github' });
+    vi.mocked(normalizeRedisUrl).mockImplementation((url) => url);
+    redisCache = new RepoCacheRedis(repository, fingerprint, url);
+  });
+
+  describe('read()', () => {
+    it('successfully reads from redis', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        get: vi.fn().mockResolvedValue(JSON.stringify(repoCache)),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await expect(redisCache.read()).resolves.toBe(JSON.stringify(repoCache));
+    });
+
+    it('returns null when cache is not found', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        get: vi.fn().mockResolvedValue(null),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await expect(redisCache.read()).resolves.toBeNull();
+    });
+
+    it('handles redis read errors gracefully', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        get: vi.fn().mockRejectedValue(err),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await expect(redisCache.read()).resolves.toBeNull();
+    });
+
+    it('reuses existing redis client', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        get: vi.fn().mockResolvedValue(JSON.stringify(repoCache)),
+        connect: vi.fn(),
+      };
+      (redisCache as any).redisClient = mockClient;
+
+      await redisCache.read();
+      await redisCache.read();
+
+      expect(createClient).not.toHaveBeenCalled();
+      expect(mockClient.connect).not.toHaveBeenCalled();
+      expect(mockClient.get).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  describe('write()', () => {
+    it('successfully writes to redis', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        set: vi.fn().mockResolvedValue('OK'),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await expect(redisCache.write(repoCache)).resolves.toBeUndefined();
+      expect(mockClient.set).toHaveBeenCalledWith(
+        'repository.github.org/repo',
+        JSON.stringify(repoCache),
+        { EX: 90 * 24 * 60 * 60 },
+      );
+    });
+
+    it('handles redis write errors gracefully', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        set: vi.fn().mockRejectedValue(err),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await expect(redisCache.write(repoCache)).resolves.toBeUndefined();
+    });
+
+    it('persists data locally when RENOVATE_X_REPO_CACHE_FORCE_LOCAL is set', async () => {
+      process.env.RENOVATE_X_REPO_CACHE_FORCE_LOCAL = 'true';
+      const mockClient: Partial<RedisClientType> = {
+        set: vi.fn().mockResolvedValue('OK'),
+        connect: vi.fn(),
+      };
+      vi.mocked(createClient).mockReturnValue(mockClient as RedisClientType);
+
+      await redisCache.write(repoCache);
+
+      expect(fs.outputCacheFile).toHaveBeenCalledWith(
+        'renovate/repository/github/org/repo.json',
+        JSON.stringify(repoCache),
+      );
+    });
+  });
+
+  describe('cleanup()', () => {
+    it('successfully disconnects from redis', async () => {
+      const mockClient: Partial<RedisClientType> = {
+        disconnect: vi.fn().mockResolvedValue(undefined),
+      };
+      (redisCache as any).redisClient = mockClient;
+
+      await redisCache.cleanup();
+
+      expect(mockClient.disconnect).toHaveBeenCalled();
+    });
+  });
+});

--- a/lib/util/cache/repository/impl/redis.ts
+++ b/lib/util/cache/repository/impl/redis.ts
@@ -1,0 +1,95 @@
+import is from '@sindresorhus/is';
+import { createClient, createCluster } from 'redis';
+import { GlobalConfig } from '../../../../config/global';
+import { logger } from '../../../../logger';
+import { outputCacheFile } from '../../../fs';
+import { normalizeRedisUrl } from '../../package/redis';
+import { getLocalCacheFileName } from '../common';
+import type { RepoCacheRecord } from '../schema';
+import { RepoCacheBase } from './base';
+
+type RedisType =
+  | ReturnType<typeof createClient>
+  | ReturnType<typeof createCluster>
+  | null;
+
+const NAMESPACE = 'repository';
+
+export class RepoCacheRedis extends RepoCacheBase {
+  private redisClient: RedisType;
+  private readonly url;
+
+  constructor(repository: string, fingerprint: string, url: string) {
+    super(repository, fingerprint);
+    this.url = url;
+    this.redisClient = null;
+  }
+
+  async read(): Promise<string | null> {
+    this.redisClient ??= await this.getRedisClient();
+    const cacheKey = this.getCacheKey();
+    try {
+      return (await this.redisClient?.get(cacheKey)) ?? null;
+    } catch {
+      logger.debug({ cacheKey }, 'Repository cache not found');
+      return null;
+    }
+  }
+
+  async write(data: RepoCacheRecord): Promise<void> {
+    this.redisClient ??= await this.getRedisClient();
+    const stringifiedCache = JSON.stringify(data);
+    const ttlDays = GlobalConfig.get('httpCacheTtlDays', 90);
+    try {
+      await this.redisClient?.set(this.getCacheKey(), stringifiedCache, {
+        EX: ttlDays * 24 * 60 * 60,
+      });
+      if (is.nonEmptyString(process.env.RENOVATE_X_REPO_CACHE_FORCE_LOCAL)) {
+        const cacheLocalFileName = getLocalCacheFileName(
+          this.platform,
+          this.repository,
+        );
+        await outputCacheFile(cacheLocalFileName, stringifiedCache);
+      }
+    } catch (err) {
+      logger.once.warn({ err }, 'Error while setting Redis cache value');
+    }
+  }
+
+  override async cleanup(): Promise<void> {
+    try {
+      // https://github.com/redis/node-redis#disconnecting
+      await this.redisClient?.disconnect();
+    } catch (err) {
+      logger.warn({ err }, 'Redis repository cache end failed');
+    }
+  }
+
+  protected getCacheKey(): string {
+    return [NAMESPACE, this.platform, this.repository].join('.');
+  }
+
+  private async getRedisClient(): Promise<RedisType> {
+    const rewrittenUrl = normalizeRedisUrl(this.url);
+    // If any replacement was made, it means the regex matched and we are in clustered mode
+    const clusteredMode = rewrittenUrl.length !== this.url.length;
+
+    const config = {
+      url: rewrittenUrl,
+      socket: {
+        reconnectStrategy: (retries: number) => {
+          // Reconnect after this time
+          return Math.min(retries * 100, 3000);
+        },
+      },
+      pingInterval: 30000, // 30s
+    };
+
+    const redisClient = clusteredMode
+      ? createCluster({ rootNodes: [config] })
+      : createClient(config);
+
+    await redisClient.connect();
+    return redisClient;
+  }
+}

--- a/lib/util/cache/repository/index.ts
+++ b/lib/util/cache/repository/index.ts
@@ -27,6 +27,10 @@ export async function saveCache(): Promise<void> {
   }
 }
 
+export async function cleanup(): Promise<void> {
+  await repoCache.cleanup();
+}
+
 export function isCacheModified(): boolean | undefined {
   return repoCache.isModified();
 }

--- a/lib/util/cache/repository/types.ts
+++ b/lib/util/cache/repository/types.ts
@@ -160,6 +160,7 @@ export interface RepoCache {
   save(): Promise<void>;
   getData(): RepoCacheData;
   isModified(): boolean | undefined;
+  cleanup(): Promise<void>;
 }
 
 export interface RepoCacheConfig {

--- a/lib/workers/repository/finalize/index.ts
+++ b/lib/workers/repository/finalize/index.ts
@@ -18,6 +18,7 @@ export async function finalizeRepo(
 ): Promise<void> {
   await checkReconfigureBranch(config);
   await repositoryCache.saveCache();
+  await repositoryCache.cleanup();
   await pruneStaleBranches(config, branchList);
   await ensureIssuesClosing();
   await clearRenovateRefs();


### PR DESCRIPTION
Redis backend is implemented analogously to the S3 backend. The only difference is that Redis client needs to be manually closed at the end, otherwise renovate is left hanging. To accomplish this, add a new cleanup method to the cache workflow that is called during repo finalization. The method is a no-op in all backends other than Redis. Cache expiration is handled by Redis, with the timeframe the same as local cache.

Unfortunately, my upstream PR has been largely ignored, so I decided to implement this to downstream renovate instead. I've tested this functionality locally and am pretty confident that it will work.