### PR TITLE
Fix branch isolation

### DIFF
--- a/lib/modules/manager/rpm/artifacts.ts
+++ b/lib/modules/manager/rpm/artifacts.ts
@@ -22,7 +22,7 @@ export async function updateArtifacts({
     `rpms.in.${extension}`,
   );
 
-  const outputName = 'rpms.lock.tmp.yaml';
+  const outputName = 'rpms.lock.yaml';
 
   logger.debug(`RPM lock file: ${packageFileName}`);
 


### PR DESCRIPTION
Turns out this invocation was necessary, otherwise the `rpms.lock.tmp.yaml` could linger from another branch and propose wrong updates.