### PR TITLE
Create RPM LockFileMaintenance vulnerability branches

### DIFF
--- a/lib/workers/repository/process/rpm-vuln-branches.spec.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.spec.ts
@@ -1,0 +1,86 @@
+import type { RenovateConfig } from '../../../config/types';
+import type { BranchConfig } from '../../types';
+import { createRPMLockFileVulnerabilityBranches } from './rpm-vuln-branches';
+
+vi.mock('../../../logger', () => ({ logger: { debug: vi.fn() } }));
+vi.mock('../../../util/clone', () => ({
+  clone: (obj: any) => JSON.parse(JSON.stringify(obj)),
+}));
+
+describe('workers/repository/process/rpm-vuln-branches', () => {
+  const baseBranch: BranchConfig = {
+    branchName: 'rpm-lockfile-maintenance',
+    baseBranch: 'main',
+    manager: 'rpm-lockfile',
+    isLockFileMaintenance: true,
+    upgrades: [
+      {
+        branchName: 'rpm-lockfile-maintenance',
+        branchTopic: 'topic',
+        manager: 'rpm-lockfile',
+        schedule: ['after 1am'],
+        commitMessageSuffix: '',
+        isVulnerabilityAlert: false,
+        vulnerabilitySeverity: undefined,
+        vulnerabilityFixStrategy: undefined,
+      },
+    ],
+    branchTopic: 'topic',
+    commitMessage: 'chore: rpm lockfile maintenance',
+    commitMessageSuffix: '',
+    prTitle: 'chore: rpm lockfile maintenance',
+    isVulnerabilityAlert: false,
+    vulnerabilitySeverity: undefined,
+    vulnerabilityFixStrategy: undefined,
+  };
+
+  it('returns original branches if rpmVulnerabilityAlerts is false', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: false } as any;
+    const branches = [baseBranch];
+    const result = createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(result).toBe(branches);
+  });
+
+  it('returns original branches if no rpm-lockfile maintenance branch', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const branches = [
+      { ...baseBranch, manager: 'npm', isLockFileMaintenance: false },
+    ];
+    const result = createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(result).toEqual(branches);
+    expect(result).toHaveLength(1);
+  });
+
+  it('duplicates and mutates rpm-lockfile maintenance branch', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const branches = [baseBranch];
+    const result = createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(result).toHaveLength(2);
+    const vulnBranch = result[1];
+    expect(vulnBranch.branchName).toBe(
+      'rpm-lockfile-maintenance-vulnerability',
+    );
+    expect(vulnBranch.upgrades[0].branchName).toBe(
+      'rpm-lockfile-maintenance-vulnerability',
+    );
+    expect(vulnBranch.branchTopic).toBe('topic-vulnerability');
+    expect(vulnBranch.upgrades[0].branchTopic).toBe('topic-vulnerability');
+    expect(vulnBranch.commitMessage).toBe(
+      'chore: rpm lockfile maintenance [SECURITY]',
+    );
+    expect(vulnBranch.upgrades[0].commitMessageSuffix).toBe('[SECURITY]');
+    expect(vulnBranch.commitMessageSuffix).toBe('[SECURITY]');
+    expect(vulnBranch.prTitle).toBe(
+      'chore: rpm lockfile maintenance [SECURITY]',
+    );
+    expect(vulnBranch.isVulnerabilityAlert).toBe(true);
+    expect(vulnBranch.upgrades[0].isVulnerabilityAlert).toBe(true);
+    expect(vulnBranch.vulnerabilitySeverity).toBe('UNKNOWN');
+    expect(vulnBranch.upgrades[0].vulnerabilitySeverity).toBe('UNKNOWN');
+    expect(vulnBranch.vulnerabilityFixStrategy).toBe('lowest');
+    expect(vulnBranch.upgrades[0].vulnerabilityFixStrategy).toBe('lowest');
+
+    const origBranch = result[0];
+    expect(origBranch).toEqual(baseBranch);
+  });
+});

--- a/lib/workers/repository/process/rpm-vuln-branches.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.ts
@@ -1,0 +1,48 @@
+import type { RenovateConfig } from '../../../config/types';
+import { logger } from '../../../logger';
+import { clone } from '../../../util/clone';
+import type { BranchConfig } from '../../types';
+
+// This function clones the RPM lockfilemaintenance branches and turns them into vulnerability branches
+// this approach is very hacky and potentially dangerous, but is reasonable for a downstream-only solution
+export function createRPMLockFileVulnerabilityBranches(
+  branches: BranchConfig[],
+  config: RenovateConfig,
+): BranchConfig[] {
+  if (config.rpmVulnerabilityAlerts === false) {
+    return branches;
+  }
+
+  const resultBranches = [...branches];
+  for (const branch of branches) {
+    if (!(branch.isLockFileMaintenance && branch.manager === 'rpm-lockfile')) {
+      continue;
+    }
+    logger.debug(
+      { branch: branch.branchName },
+      'RPM lockfile maintenance branch found',
+    );
+
+    const copiedBranch = clone(branch);
+    // change some settings to make the it a vulnerability branch
+    copiedBranch.schedule = [];
+    copiedBranch.upgrades[0].schedule = [];
+    copiedBranch.branchName = `${branch.branchName}-vulnerability`;
+    copiedBranch.upgrades[0].branchName = `${branch.branchName}-vulnerability`;
+    copiedBranch.branchTopic = `${branch.branchTopic}-vulnerability`;
+    copiedBranch.upgrades[0].branchTopic = `${branch.branchTopic}-vulnerability`;
+    copiedBranch.commitMessage = `${branch.commitMessage} [SECURITY]`;
+    copiedBranch.upgrades[0].commitMessageSuffix = '[SECURITY]';
+    copiedBranch.commitMessageSuffix = '[SECURITY]';
+    copiedBranch.prTitle = `${branch.prTitle} [SECURITY]`;
+    copiedBranch.isVulnerabilityAlert = true;
+    copiedBranch.upgrades[0].isVulnerabilityAlert = true;
+    copiedBranch.vulnerabilitySeverity = 'UNKNOWN';
+    copiedBranch.upgrades[0].vulnerabilitySeverity = 'UNKNOWN';
+    copiedBranch.vulnerabilityFixStrategy = 'lowest';
+    copiedBranch.upgrades[0].vulnerabilityFixStrategy = 'lowest';
+
+    resultBranches.push(copiedBranch);
+  }
+  return resultBranches;
+}

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -16,6 +16,7 @@ import {
   getConcurrentPrsCount,
   getPrHourlyCount,
 } from './limits';
+import { createRPMLockFileVulnerabilityBranches } from './rpm-vuln-branches';
 
 export type WriteUpdateResult = 'done' | 'automerged';
 
@@ -116,7 +117,8 @@ export async function writeUpdates(
   config: RenovateConfig,
   allBranches: BranchConfig[],
 ): Promise<WriteUpdateResult> {
-  const branches = allBranches;
+  const branches = createRPMLockFileVulnerabilityBranches(allBranches, config);
+
   logger.debug(
     `Processing ${branches.length} branch${
       branches.length === 1 ? '' : 'es'


### PR DESCRIPTION
If a branch is detected to be for RPM LockFileMaintenance, it is cloned
and the copy is modified to become a vulnerability branch. The settings
that are changed are branch name, commit message, PR title, schedule,
and vulnerability related settings. As mentioned by renovate
manitainers, it can be dangerous to change these settings later in the
code, so they are changed early and set to predictable values. Other
settings modifying the PR message etc. will be changed later depending
on what vulnerabilities are found.

The original RPM branches are kept the same, so their behavior will not
be modified. For now, they will coexist with the vulnerability branches,
but perhaps a new logic can be added later to disable them if a
vulnerability is found.

The new logic respects rpmVulnerabilityAlerts, and will not create the
new branches if it's set to false. This will effectively disable RPM
vulnerability PRs with this new workflow.

The vulnerability related settings ensure that the new branch is always
processed. For now it means that its PR will always be created, but
later this will depend on whether any vulnerabilities were found.

Jira: CLOUDDST-28761

Examples:
Normal PRs are being created: https://github.com/querti/renovate-tests/pull/264 https://github.com/querti/renovate-tests/pull/263
Simultaniously, security PRs are being created: https://github.com/querti/renovate-tests/pull/266 https://github.com/querti/renovate-tests/pull/265
The PRs also demonstrate that multiple branches are supported, for example in the case of multiple base branches or when splitting the PRs by files is desired.
