### PR TITLE
Implement the logic to handle RPM vulnerability branches

### DIFF
--- a/lib/workers/repository/index.ts
+++ b/lib/workers/repository/index.ts
@@ -40,6 +40,7 @@ import { OnboardingState } from './onboarding/common';
 import { ensureOnboardingPr } from './onboarding/pr';
 import { extractDependencies, updateRepo } from './process';
 import type { ExtractResult } from './process/extract-update';
+import { createRPMLockFileVulnerabilityBranches } from './process/rpm-vuln-branches';
 import type { ProcessResult } from './result';
 import { processResult } from './result';
 
@@ -74,7 +75,11 @@ export async function renovateRepository(
       : emptyExtract(config);
     addExtractionStats(config, extractResult);
 
-    const { branches, branchList, packageFiles } = extractResult;
+    const [branches, branchList] = createRPMLockFileVulnerabilityBranches(
+      extractResult.branches,
+      config,
+    );
+    const packageFiles = extractResult.packageFiles;
 
     if (config.semanticCommits === 'auto') {
       config.semanticCommits = await detectSemanticCommits();

--- a/lib/workers/repository/process/rpm-vuln-branches.spec.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.spec.ts
@@ -37,8 +37,10 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
   it('returns original branches if rpmVulnerabilityAlerts is false', () => {
     const config: RenovateConfig = { rpmVulnerabilityAlerts: false } as any;
     const branches = [baseBranch];
-    const result = createRPMLockFileVulnerabilityBranches(branches, config);
-    expect(result).toBe(branches);
+    const [resultBranches, branchNames] =
+      createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(resultBranches).toBe(branches);
+    expect(branchNames).toEqual(branches.map((b) => b.branchName));
   });
 
   it('returns original branches if no rpm-lockfile maintenance branch', () => {
@@ -46,17 +48,22 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     const branches = [
       { ...baseBranch, manager: 'npm', isLockFileMaintenance: false },
     ];
-    const result = createRPMLockFileVulnerabilityBranches(branches, config);
-    expect(result).toEqual(branches);
-    expect(result).toHaveLength(1);
+    const [resultBranches, branchNames] =
+      createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(resultBranches).toEqual(branches);
+    expect(resultBranches).toHaveLength(1);
+    expect(branchNames).toEqual(branches.map((b) => b.branchName));
   });
 
   it('duplicates and mutates rpm-lockfile maintenance branch', () => {
     const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
     const branches = [baseBranch];
-    const result = createRPMLockFileVulnerabilityBranches(branches, config);
-    expect(result).toHaveLength(2);
-    const vulnBranch = result[1];
+    const [resultBranches, branchNames] =
+      createRPMLockFileVulnerabilityBranches(branches, config);
+    expect(resultBranches).toHaveLength(2);
+    expect(branchNames).toHaveLength(2);
+    expect(branchNames).toEqual(resultBranches.map((b) => b.branchName));
+    const vulnBranch = resultBranches[1];
     expect(vulnBranch.branchName).toBe(
       'rpm-lockfile-maintenance-vulnerability',
     );
@@ -80,7 +87,7 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     expect(vulnBranch.vulnerabilityFixStrategy).toBe('lowest');
     expect(vulnBranch.upgrades[0].vulnerabilityFixStrategy).toBe('lowest');
 
-    const origBranch = result[0];
+    const origBranch = resultBranches[0];
     expect(origBranch).toEqual(baseBranch);
   });
 });

--- a/lib/workers/repository/process/rpm-vuln-branches.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.ts
@@ -8,9 +8,9 @@ import type { BranchConfig } from '../../types';
 export function createRPMLockFileVulnerabilityBranches(
   branches: BranchConfig[],
   config: RenovateConfig,
-): BranchConfig[] {
+): [BranchConfig[], string[]] {
   if (config.rpmVulnerabilityAlerts === false) {
-    return branches;
+    return [branches, branches.map((branch) => branch.branchName)];
   }
 
   const resultBranches = [...branches];
@@ -44,5 +44,6 @@ export function createRPMLockFileVulnerabilityBranches(
 
     resultBranches.push(copiedBranch);
   }
-  return resultBranches;
+  const branchNames = resultBranches.map((branch) => branch.branchName);
+  return [resultBranches, branchNames];
 }

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -16,7 +16,6 @@ import {
   getConcurrentPrsCount,
   getPrHourlyCount,
 } from './limits';
-import { createRPMLockFileVulnerabilityBranches } from './rpm-vuln-branches';
 
 export type WriteUpdateResult = 'done' | 'automerged';
 
@@ -117,7 +116,7 @@ export async function writeUpdates(
   config: RenovateConfig,
   allBranches: BranchConfig[],
 ): Promise<WriteUpdateResult> {
-  const branches = createRPMLockFileVulnerabilityBranches(allBranches, config);
+  const branches = allBranches;
 
   logger.debug(
     `Processing ${branches.length} branch${

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1,6 +1,7 @@
 import is from '@sindresorhus/is';
 import { mockDeep } from 'vitest-mock-extended';
 import { GitRefsDatasource } from '../../../../modules/datasource/git-refs';
+import * as managerModule from '../../../../modules/manager';
 import * as _batectWrapper from '../../../../modules/manager/batect-wrapper';
 import * as _bundler from '../../../../modules/manager/bundler';
 import * as _composer from '../../../../modules/manager/composer';
@@ -18,7 +19,8 @@ import type {
 } from '../../../../modules/manager/types';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 import * as _autoReplace from './auto-replace';
-import { getUpdatedPackageFiles } from './get-updated';
+import { getUpdatedPackageFiles, managerUpdateArtifacts } from './get-updated';
+import * as rpmVulnPostProcessing from './rpm-vuln-post-processing';
 import { git } from '~test/util';
 
 const bundler = vi.mocked(_bundler);
@@ -1054,6 +1056,83 @@ describe('workers/repository/update/branch/get-updated', () => {
           expect.objectContaining({ packageFileName: 'requirements-dev.in' }),
         );
       });
+    });
+  });
+
+  describe('managerUpdateArtifacts', () => {
+    const updateArtifact = {
+      packageFileName: 'file',
+      updatedDeps: [],
+      newPackageFileContent: 'content',
+      config: {},
+    };
+    const config: any = {
+      isLockFileMaintenance: false,
+      isVulnerabilityAlert: false,
+    };
+    const manager = 'npm';
+
+    afterEach(() => {
+      vi.restoreAllMocks();
+    });
+
+    it('calls updateArtifacts and returns result', async () => {
+      const mockUpdateArtifacts = vi
+        .fn()
+        .mockResolvedValue([
+          { file: { path: 'file', contents: 'abc', type: 'addition' } },
+        ]);
+      vi.spyOn(managerModule, 'get').mockReturnValue(mockUpdateArtifacts);
+      const result = await managerUpdateArtifacts(
+        manager,
+        updateArtifact,
+        config,
+      );
+      expect(mockUpdateArtifacts).toHaveBeenCalledWith(updateArtifact);
+      expect(result).toEqual([
+        { file: { path: 'file', contents: 'abc', type: 'addition' } },
+      ]);
+    });
+
+    it('returns null if updateArtifacts is not defined', async () => {
+      vi.spyOn(managerModule, 'get').mockReturnValue(undefined);
+      const result = await managerUpdateArtifacts(
+        manager,
+        updateArtifact,
+        config,
+      );
+      expect(result).toBeNull();
+    });
+
+    it('calls postProcessRPMVulnerabilities for rpm-lockfile manager', async () => {
+      const rpmConfig = {
+        isLockFileMaintenance: true,
+        isVulnerabilityAlert: true,
+      };
+      const mockUpdateArtifacts = vi
+        .fn()
+        .mockResolvedValue([
+          { file: { path: 'file', contents: 'abc', type: 'addition' } },
+        ]);
+      const mockPostProcess = vi
+        .spyOn(rpmVulnPostProcessing, 'postProcessRPMVulnerabilities')
+        .mockReturnValue([
+          { file: { path: 'processed', contents: 'xyz', type: 'addition' } },
+        ]);
+      vi.spyOn(managerModule, 'get').mockReturnValue(mockUpdateArtifacts);
+      const result = await managerUpdateArtifacts(
+        'rpm-lockfile',
+        updateArtifact,
+        rpmConfig as any,
+      );
+      expect(mockUpdateArtifacts).toHaveBeenCalledWith(updateArtifact);
+      expect(mockPostProcess).toHaveBeenCalledWith(
+        [{ file: { path: 'file', contents: 'abc', type: 'addition' } }],
+        rpmConfig,
+      );
+      expect(result).toEqual([
+        { file: { path: 'processed', contents: 'xyz', type: 'addition' } },
+      ]);
     });
   });
 });

--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -17,6 +17,7 @@ import type { FileAddition, FileChange } from '../../../../util/git/types';
 import { coerceString } from '../../../../util/string';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 import { doAutoReplace } from './auto-replace';
+import { postProcessRPMVulnerabilities } from './rpm-vuln-post-processing';
 
 export interface PackageFilesResult {
   artifactErrors: ArtifactError[];
@@ -332,17 +333,21 @@ export async function getUpdatedPackageFiles(
       sortPackageFiles(config, manager, packageFilesForManager);
       for (const packageFile of packageFilesForManager) {
         const updatedDeps = packageFileUpdatedDeps[packageFile.path];
-        const results = await managerUpdateArtifacts(manager, {
-          packageFileName: packageFile.path,
-          updatedDeps,
-          // TODO #22198
-          newPackageFileContent: packageFile.contents!.toString(),
-          config: patchConfigForArtifactsUpdate(
-            config,
-            manager,
-            packageFile.path,
-          ),
-        });
+        const results = await managerUpdateArtifacts(
+          manager,
+          {
+            packageFileName: packageFile.path,
+            updatedDeps,
+            // TODO #22198
+            newPackageFileContent: packageFile.contents!.toString(),
+            config: patchConfigForArtifactsUpdate(
+              config,
+              manager,
+              packageFile.path,
+            ),
+          },
+          config,
+        );
         processUpdateArtifactResults(
           results,
           updatedArtifacts,
@@ -373,17 +378,21 @@ export async function getUpdatedPackageFiles(
       sortPackageFiles(config, manager, packageFilesForManager);
       for (const packageFile of packageFilesForManager) {
         const updatedDeps = packageFileUpdatedDeps[packageFile.path];
-        const results = await managerUpdateArtifacts(manager, {
-          packageFileName: packageFile.path,
-          updatedDeps,
-          // TODO #22198
-          newPackageFileContent: packageFile.contents!.toString(),
-          config: patchConfigForArtifactsUpdate(
-            config,
-            manager,
-            packageFile.path,
-          ),
-        });
+        const results = await managerUpdateArtifacts(
+          manager,
+          {
+            packageFileName: packageFile.path,
+            updatedDeps,
+            // TODO #22198
+            newPackageFileContent: packageFile.contents!.toString(),
+            config: patchConfigForArtifactsUpdate(
+              config,
+              manager,
+              packageFile.path,
+            ),
+          },
+          config,
+        );
         processUpdateArtifactResults(
           results,
           updatedArtifacts,
@@ -418,16 +427,20 @@ export async function getUpdatedPackageFiles(
           const contents =
             updatedFileContents[packageFile.path] ||
             (await getFile(packageFile.path, config.baseBranch));
-          const results = await managerUpdateArtifacts(manager, {
-            packageFileName: packageFile.path,
-            updatedDeps: [],
-            newPackageFileContent: contents!,
-            config: patchConfigForArtifactsUpdate(
-              config,
-              manager,
-              packageFile.path,
-            ),
-          });
+          const results = await managerUpdateArtifacts(
+            manager,
+            {
+              packageFileName: packageFile.path,
+              updatedDeps: [],
+              newPackageFileContent: contents!,
+              config: patchConfigForArtifactsUpdate(
+                config,
+                manager,
+                packageFile.path,
+              ),
+            },
+            config,
+          );
           processUpdateArtifactResults(
             results,
             updatedArtifacts,
@@ -468,13 +481,23 @@ function patchConfigForArtifactsUpdate(
   return updatedConfig;
 }
 
-async function managerUpdateArtifacts(
+export async function managerUpdateArtifacts(
   manager: string,
   updateArtifact: UpdateArtifact,
+  config: BranchConfig,
 ): Promise<UpdateArtifactsResult[] | null> {
   const updateArtifacts = get(manager, 'updateArtifacts');
   if (updateArtifacts) {
-    return await updateArtifacts(updateArtifact);
+    const result = await updateArtifacts(updateArtifact);
+    if (
+      manager === 'rpm-lockfile' &&
+      config.isLockFileMaintenance &&
+      config.isVulnerabilityAlert
+    ) {
+      return postProcessRPMVulnerabilities(result, config);
+    } else {
+      return result;
+    }
   }
   return null;
 }

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -55,6 +55,17 @@ async function rebaseCheck(
   config: RenovateConfig,
   branchPr: Pr,
 ): Promise<boolean> {
+  // special case: if the PR is a vulnerability alert, we always rebase.
+  // The reason is that we always want the lockfilemaintenance and post-processing
+  // code to run in these cases. This way, the PR body will always have the correct information.
+  // If this was skipped, the PR body would not have any vulnerability data
+  if (
+    config.manager === 'rpm-lockfile' &&
+    config.isLockFileMaintenance &&
+    config.isVulnerabilityAlert
+  ) {
+    return true;
+  }
   const titleRebase = branchPr.title?.startsWith('rebase!');
   if (titleRebase) {
     logger.debug(

--- a/lib/workers/repository/update/branch/rpm-vuln-post-processing.ts
+++ b/lib/workers/repository/update/branch/rpm-vuln-post-processing.ts
@@ -1,0 +1,30 @@
+import { logger } from '../../../../logger';
+import type { UpdateArtifactsResult } from '../../../../modules/manager/types';
+import type { BranchConfig } from '../../../types';
+
+export function postProcessRPMVulnerabilities(
+  result: UpdateArtifactsResult[] | null,
+  config: BranchConfig,
+): UpdateArtifactsResult[] | null {
+  logger.debug('RPM vulnerability post-processing');
+  if (result === null) {
+    logger.debug('No RPM updates have been proposed');
+    return result;
+  }
+
+  // TODO: parse the result, find vulnerabilities, render the PR body
+  // DUMMY CODE. Simulation of found vulnerabilities.
+  if (
+    config.branchName ===
+    'renovate/lock-file-maintenance-rpms.in.yaml-vulnerability'
+  ) {
+    // if vulnerability is found, update the PR message with the information
+    config.prHeader = 'RPM vulnerability post-processing';
+  } else {
+    // if no vulnerability is found, pretend that the lockfilemaintenance is a no-op
+    // This way no PR will be created and the evaluation should be safe and consistent
+    return null;
+  }
+
+  return result;
+}


### PR DESCRIPTION
The new code should ensure that the RPM vulnerability branches are handled correctly by Renovate. The solution was designed in a way to not alter any general renovate workflow logic and to only affect the RPM vulnerability branches. This way, the risk of regressions is minimized and any upstream alterations should not affect the new code. When possible, existing features and approaches were used to modify the behavior. This should ensure that the new logic remains compatible even if the underlying code is changed.

Following changes were made:
- The function that calls the lockfileMaintenance code, managerUpdateArtifacts, now calls postProcessRPMVulnerabilities for the RPM vulnerability branches afterwards. It takes a new parameter, config, which must be modified to alter the PR body.
- Vulnerability branches are now created in a parent function. This ensures that the full renovate workflow is aware of these branches and PruneStaleBranches is now compatible with RPM vulnerabilities.
- The new function postProcessRPMVulnerabilities is mostly a placeholder for now, but later it will be responsible for finding vulnerabilities and adding them to the PR body. The function returns null if no vulnerabilities are found. This causes the PR not to be created/updated and should generally be safe, since null is returned by LockFileMaintenance if no changes are detected.
- Function rebaseCheck now always returns true for RPM vulnerability branches. This is required because otherwise the code for running LockfileMaintenance (and post processing) is skipped for existing PRs. We always want the proposed updates to be up-to-date and we need to run the post-processing to ensure that the PR has correct information. This alteration should be generally safe since requesting a rebase is always a valid workflow for existing PRs

The following scenarios were tested and work correctly:
- Security PR will be created if the lockfile has changed
- Security PR will not be created if the lockfile has not changed
- If the PR is closed, new one will be recreated
- If the PR is merged, new one will be created
- If a PR is open and proposed updates have changed, the PR is updated
- If a security PR is open and now if fixes more/less/other CVEs, the PR body is changed accordingly
- If lockfile changes were detected, but they are not security changes (simulated), no PR is created
- If a PR is open and (somehow) it is no longer a security update, the PR will be kept open and its description will be changed to a base one. This is a niche scenario, and the behavior is in line with pruneStaleBranches=false
- PR is open and the lockfile in the base branch has changed. PR is correctly rebased to the base branch
- Regular RPM PR is open alongside the security one. There is no interference between the PRs
- Rebase checkmark is checked on a security PR. It has no effect because rebase is enabled by default
- Security PR branch is deleted. A new one is created for the next PR
- Security PR branch still exists after it's merged. The branch is reused for the next PR
- rpmVulnerabilityAlerts is set to False. New security PRs are no longer being created but the existing ones are kept open and ignored by renovate
- pruneStaleBranches is set to True. This feature never removes security RPM branches. This is not correct in the case of merged/ closed PRs, but I think it's better to keep the code simple and keep this regression.
- There are multiple RPM security PRs (for example due to multiple base branches or one lockfile per PR is configured). The PRs are correctly created and updated and don't interfere with each other
- Regular RPM PR is outside of its schedule. It is not created, but its security counterpart is created

There are following known issues with this implementation:
- The security PRs coexist with non-security PRs. The non-security PR are not closed when a security PR is created and they stay open after it is merged. As far as I know this behavior is the same for security updates in other ecosystems. Personally, I think that implementing this would not be worth the increased code complexity
- pruneStaleBranches=true will always ignore the RPM security branches. This is not a big deal since we don't use this feature anyway. But perhaps it could be possible to implement it sometime later.
- Open RPM security PRs will always force a rebase. This should be completely safe, but it will cause a long PR history since every force push is recorded there.

Jira: CLOUDDST-28762