### PR TITLE
Implement post-processing for RPM security PRs

### DIFF
--- a/lib/modules/manager/rpm-lockfile/index.ts
+++ b/lib/modules/manager/rpm-lockfile/index.ts
@@ -10,6 +10,9 @@ export const supportedDatasources = [RPMLockfileDatasource.id];
 
 export const defaultConfig = {
   managerFilePatterns: ['/(^|/)(rpms\\.in\\.ya?ml)$/'],
+  lockFileMaintenance: {
+    commitMessageAction: 'Refresh RPM lockfiles',
+  },
 };
 
 export const categories: Category[] = ['rpm'];

--- a/lib/workers/repository/process/write.ts
+++ b/lib/workers/repository/process/write.ts
@@ -165,8 +165,13 @@ export async function writeUpdates(
       branchState,
       commitFingerprint,
     );
+    const forceRebase = Boolean(
+      branch.manager === 'rpm-lockfile' &&
+        branch.isLockFileMaintenance &&
+        branch.isVulnerabilityAlert,
+    );
 
-    const res = await processBranch(branch);
+    const res = await processBranch(branch, forceRebase);
     branch.prBlockedBy = res?.prBlockedBy;
     branch.prNo = res?.prNo;
     branch.result = res?.result;

--- a/lib/workers/repository/update/branch/get-updated.spec.ts
+++ b/lib/workers/repository/update/branch/get-updated.spec.ts
@@ -1261,7 +1261,7 @@ describe('workers/repository/update/branch/get-updated', () => {
         ]);
       const mockPostProcess = vi
         .spyOn(rpmVulnPostProcessing, 'postProcessRPMVulnerabilities')
-        .mockReturnValue([
+        .mockResolvedValue([
           { file: { path: 'processed', contents: 'xyz', type: 'addition' } },
         ]);
       vi.spyOn(managerModule, 'get').mockReturnValue(mockUpdateArtifacts);

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -55,17 +55,6 @@ async function rebaseCheck(
   config: RenovateConfig,
   branchPr: Pr,
 ): Promise<boolean> {
-  // special case: if the PR is a vulnerability alert, we always rebase.
-  // The reason is that we always want the lockfilemaintenance and post-processing
-  // code to run in these cases. This way, the PR body will always have the correct information.
-  // If this was skipped, the PR body would not have any vulnerability data
-  if (
-    config.manager === 'rpm-lockfile' &&
-    config.isLockFileMaintenance &&
-    config.isVulnerabilityAlert
-  ) {
-    return true;
-  }
   const titleRebase = branchPr.title?.startsWith('rebase!');
   if (titleRebase) {
     logger.debug(

--- a/lib/workers/repository/update/branch/rpm-vuln-post-processing.spec.ts
+++ b/lib/workers/repository/update/branch/rpm-vuln-post-processing.spec.ts
@@ -1,0 +1,316 @@
+import { RedHatRPMLockfile } from '../../../../modules/manager/rpm/schema';
+import { parseSingleYaml } from '../../../../util/yaml';
+import { RpmVulnerabilities } from '../../process/rpm-vulnerabilities';
+import {
+  applyVulnerabilityPRNotes,
+  createVulnerabilities,
+  parseLockfilePackages,
+  postProcessRPMVulnerabilities,
+} from './rpm-vuln-post-processing';
+
+describe('workers/repository/update/branch/rpm-vuln-post-processing', () => {
+  describe('parseLockfilePackages()', () => {
+    const oldYaml = `
+lockfileVersion: 1
+lockfileVendor: RedHat
+arches:
+  - arch: x86_64
+    packages:
+      - url: http://example/p1
+        repoid: base
+        size: 123
+        checksum: abc
+        name: pkg1
+        evr: "1.0"
+        sourcerpm: src1
+      - url: http://example/p2
+        repoid: base
+        size: 456
+        checksum: def
+        name: pkg2
+        evr: "2.0"
+        sourcerpm: src2
+`;
+
+    const newYamlChanged = `
+lockfileVersion: 1
+lockfileVendor: RedHat
+arches:
+  - arch: x86_64
+    packages:
+      - url: http://example/p1
+        repoid: base
+        size: 123
+        checksum: abc
+        name: pkg1
+        evr: "1.1"
+        sourcerpm: src1
+      - url: http://example/p2
+        repoid: base
+        size: 456
+        checksum: def
+        name: pkg2
+        evr: "2.0"
+        sourcerpm: src2
+`;
+
+    it('returns only packages with changed versions', () => {
+      const results = [
+        {
+          file: {
+            type: 'addition',
+            path: 'packages.lock.yaml',
+            previousContents: oldYaml,
+            contents: newYamlChanged,
+          },
+        },
+      ];
+      const pkgs = parseLockfilePackages(results as any);
+      expect(pkgs).toHaveLength(1);
+      expect(pkgs[0]).toMatchObject({
+        depName: 'pkg1',
+        packageName: 'pkg1',
+        currentVersion: '1.0',
+        newVersion: '1.1',
+        versioning: 'rpm',
+        datasource: 'rpm-lockfile',
+      });
+    });
+
+    it('parses our sample lockfile with schema', () => {
+      const parsed = parseSingleYaml(oldYaml, {
+        customSchema: RedHatRPMLockfile,
+      });
+      expect(parsed.arches[0].arch).toBe('x86_64');
+      expect(parsed.arches[0].packages).toHaveLength(2);
+    });
+
+    it('returns empty on parse error', () => {
+      const results = [
+        {
+          file: {
+            type: 'addition',
+            path: 'packages.lock.yaml',
+            previousContents: 'not: valid: yaml: 1',
+            contents: 'also: invalid: 2',
+          },
+        },
+      ];
+      const pkgs = parseLockfilePackages(results as any);
+      expect(pkgs).toEqual([]);
+    });
+  });
+
+  describe('createVulnerabilities()', () => {
+    it('flattens and de-duplicates by vulnerability id', async () => {
+      const packages = [
+        {
+          depName: 'pkg1',
+          packageName: 'pkg1',
+          currentVersion: '1.0',
+          currentValue: '1.0',
+          newVersion: '1.1',
+          newValue: '1.1',
+          versioning: 'rpm',
+          datasource: 'rpm-lockfile',
+        },
+        {
+          depName: 'pkg2',
+          packageName: 'pkg2',
+          currentVersion: '2.0',
+          currentValue: '2.0',
+          newVersion: '2.1',
+          newValue: '2.1',
+          versioning: 'rpm',
+          datasource: 'rpm-lockfile',
+        },
+      ];
+
+      const rpmVulns: Partial<RpmVulnerabilities> = {
+        fetchDependencyVulnerability: vi
+          .fn()
+          .mockResolvedValueOnce({
+            vulnerabilities: [
+              {
+                vulnerability: { id: 'VULN-1' },
+                affected: {},
+              },
+              {
+                vulnerability: { id: 'VULN-2' },
+                affected: {},
+              },
+            ],
+          })
+          .mockResolvedValueOnce({
+            vulnerabilities: [
+              {
+                vulnerability: { id: 'VULN-2' },
+                affected: {},
+              },
+              {
+                vulnerability: { id: 'VULN-3' },
+                affected: {},
+              },
+            ],
+          }),
+      } as any;
+
+      const vulns = await createVulnerabilities(
+        packages as any,
+        rpmVulns as unknown as RpmVulnerabilities,
+      );
+      expect(vulns.map((v) => v.vulnerability.id).sort()).toEqual([
+        'VULN-1',
+        'VULN-2',
+        'VULN-3',
+      ]);
+    });
+  });
+
+  describe('applyVulnerabilityPRNotes()', () => {
+    it('appends notes to config and first upgrade', () => {
+      const rpmVulns: Partial<RpmVulnerabilities> = {
+        generatePrBodyNotes: vi.fn().mockReturnValue(['note-a', 'note-b']),
+      } as any;
+
+      const config: any = {
+        upgrades: [{ prBodyNotes: ['existing'] }],
+      };
+
+      const vulnerabilities: any[] = [
+        { vulnerability: { id: 'A' }, affected: {} },
+        { vulnerability: { id: 'B' }, affected: {} },
+      ];
+
+      applyVulnerabilityPRNotes(
+        vulnerabilities as any,
+        config,
+        rpmVulns as any,
+      );
+
+      expect(config.prBodyNotes).toEqual([
+        'note-a',
+        'note-b',
+        'note-a',
+        'note-b',
+      ]);
+      expect(config.upgrades[0].prBodyNotes).toEqual([
+        'existing',
+        'note-a',
+        'note-b',
+        'note-a',
+        'note-b',
+      ]);
+    });
+
+    it('passes truncated=true when total notes would exceed 10', () => {
+      const gen = vi.fn().mockReturnValue(['n']);
+      const rpmVulns: Partial<RpmVulnerabilities> = {
+        generatePrBodyNotes: gen,
+      } as any;
+
+      const config: any = {
+        upgrades: [{ prBodyNotes: new Array(9).fill('e') }],
+      };
+      const vulnerabilities: any[] = [
+        { vulnerability: { id: 'A' }, affected: {} },
+        { vulnerability: { id: 'B' }, affected: {} },
+      ];
+
+      applyVulnerabilityPRNotes(
+        vulnerabilities as any,
+        config,
+        rpmVulns as any,
+      );
+
+      // called twice, with truncated true and isFirst flag as false
+      expect(gen).toHaveBeenCalledTimes(2);
+      const args = gen.mock.calls[0];
+      expect(args[2]).toBe(true);
+      expect(args[3]).toBe(false);
+    });
+  });
+
+  describe('postProcessRPMVulnerabilities()', () => {
+    const buildLockfileResult = (oldEvr: string, newEvr: string) => {
+      const oldYaml = `
+lockfileVersion: 1
+lockfileVendor: RedHat
+arches:
+  - arch: x86_64
+    packages:
+      - url: http://example/p1
+        repoid: base
+        size: 123
+        checksum: abc
+        name: pkg1
+        evr: "${oldEvr}"
+        sourcerpm: src1
+`;
+      const newYaml = oldYaml.replace(`evr: "${oldEvr}"`, `evr: "${newEvr}"`);
+      return [
+        {
+          file: {
+            type: 'addition',
+            path: 'packages.lock.yaml',
+            previousContents: oldYaml,
+            contents: newYaml,
+          },
+        },
+      ];
+    };
+
+    it('returns null when result is null', async () => {
+      const cfg: any = { upgrades: [{}] };
+      const res = await postProcessRPMVulnerabilities(null, cfg);
+      expect(res).toBeNull();
+    });
+
+    it('returns null when no packages parsed', async () => {
+      const cfg: any = { upgrades: [{}] };
+      const results = [
+        {
+          file: {
+            type: 'deletion',
+            path: 'packages.lock.yaml',
+          },
+        },
+      ];
+      const res = await postProcessRPMVulnerabilities(results as any, cfg);
+      expect(res).toBeNull();
+    });
+
+    it('returns null when no vulnerabilities found', async () => {
+      const fake: Partial<RpmVulnerabilities> = {
+        fetchDependencyVulnerability: vi.fn().mockResolvedValue(null),
+        generatePrBodyNotes: vi.fn().mockReturnValue([]),
+      } as any;
+      vi.spyOn(RpmVulnerabilities, 'create').mockResolvedValue(fake as any);
+
+      const cfg: any = { upgrades: [{}] };
+      const results = buildLockfileResult('1.0', '1.1');
+      const res = await postProcessRPMVulnerabilities(results as any, cfg);
+      expect(res).toBeNull();
+    });
+
+    it('applies PR notes and returns original result on vulnerabilities', async () => {
+      const fake: Partial<RpmVulnerabilities> = {
+        fetchDependencyVulnerability: vi.fn().mockResolvedValue({
+          vulnerabilities: [
+            { vulnerability: { id: 'A' }, affected: {} },
+            { vulnerability: { id: 'B' }, affected: {} },
+          ],
+        }),
+        generatePrBodyNotes: vi.fn().mockReturnValue(['note']),
+      } as any;
+      vi.spyOn(RpmVulnerabilities, 'create').mockResolvedValue(fake as any);
+
+      const cfg: any = { upgrades: [{}] };
+      const results = buildLockfileResult('1.0', '1.1');
+      const res = await postProcessRPMVulnerabilities(results as any, cfg);
+      expect(res).toBe(results as any);
+      expect(cfg.prBodyNotes).toEqual(['note', 'note']);
+      expect(cfg.upgrades[0].prBodyNotes).toEqual(['note', 'note']);
+    });
+  });
+});

--- a/lib/workers/repository/update/branch/rpm-vuln-post-processing.ts
+++ b/lib/workers/repository/update/branch/rpm-vuln-post-processing.ts
@@ -1,30 +1,180 @@
+import is from '@sindresorhus/is';
 import { logger } from '../../../../logger';
-import type { UpdateArtifactsResult } from '../../../../modules/manager/types';
+import { RedHatRPMLockfile } from '../../../../modules/manager/rpm/schema';
+import type {
+  PackageDependency,
+  UpdateArtifactsResult,
+} from '../../../../modules/manager/types';
+import * as p from '../../../../util/promises';
+import { parseSingleYaml } from '../../../../util/yaml';
 import type { BranchConfig } from '../../../types';
+import { RpmVulnerabilities } from '../../process/rpm-vulnerabilities';
+import type {
+  DependencyVulnerabilities,
+  Vulnerability,
+} from '../../process/types';
 
-export function postProcessRPMVulnerabilities(
+export async function postProcessRPMVulnerabilities(
   result: UpdateArtifactsResult[] | null,
   config: BranchConfig,
-): UpdateArtifactsResult[] | null {
+): Promise<UpdateArtifactsResult[] | null> {
   logger.debug('RPM vulnerability post-processing');
   if (result === null) {
     logger.debug('No RPM updates have been proposed');
-    return result;
-  }
-
-  // TODO: parse the result, find vulnerabilities, render the PR body
-  // DUMMY CODE. Simulation of found vulnerabilities.
-  if (
-    config.branchName ===
-    'renovate/lock-file-maintenance-rpms.in.yaml-vulnerability'
-  ) {
-    // if vulnerability is found, update the PR message with the information
-    config.prHeader = 'RPM vulnerability post-processing';
-  } else {
-    // if no vulnerability is found, pretend that the lockfilemaintenance is a no-op
-    // This way no PR will be created and the evaluation should be safe and consistent
     return null;
   }
 
+  const packages = parseLockfilePackages(result);
+  if (packages.length === 0) {
+    logger.warn('No RPM packages could be parsed');
+    return null;
+  }
+
+  const rpmVulnerabilities = await RpmVulnerabilities.create();
+  const vulnerabilities = await createVulnerabilities(
+    packages,
+    rpmVulnerabilities,
+  );
+  logger.debug(`Found ${vulnerabilities.length} vulnerabilities`);
+
+  if (vulnerabilities.length === 0) {
+    logger.debug('No RPM vulnerabilities found');
+    return null;
+  }
+
+  applyVulnerabilityPRNotes(vulnerabilities, config, rpmVulnerabilities);
+
   return result;
+}
+
+export function parseLockfilePackages(
+  results: UpdateArtifactsResult[],
+): PackageDependency[] {
+  const oldPackages = new Map<string, PackageDependency>();
+  const newPackages = new Map<string, PackageDependency>();
+  for (const result of results) {
+    if (result?.file?.type !== 'addition') {
+      continue;
+    }
+    const oldLockFileContent = result.file.previousContents;
+    const newLockFileContent = result.file.contents;
+
+    if (
+      typeof oldLockFileContent === 'string' &&
+      typeof newLockFileContent === 'string'
+    ) {
+      try {
+        const oldLockFile = parseSingleYaml(oldLockFileContent, {
+          customSchema: RedHatRPMLockfile,
+        });
+        const newLockFile = parseSingleYaml(newLockFileContent, {
+          customSchema: RedHatRPMLockfile,
+        });
+        for (const arch of oldLockFile.arches) {
+          for (const dependency of arch.packages) {
+            const key = `${arch.arch}-${dependency.name}`;
+            oldPackages.set(key, {
+              depName: dependency.name,
+              packageName: dependency.name,
+              currentValue: dependency.evr,
+              currentVersion: dependency.evr,
+              versioning: 'rpm',
+              datasource: 'rpm-lockfile',
+            });
+          }
+        }
+
+        for (const arch of newLockFile.arches) {
+          for (const dependency of arch.packages) {
+            const key = `${arch.arch}-${dependency.name}`;
+            newPackages.set(key, {
+              depName: dependency.name,
+              packageName: dependency.name,
+              currentValue: dependency.evr,
+              currentVersion: dependency.evr,
+              versioning: 'rpm',
+              datasource: 'rpm-lockfile',
+            });
+          }
+        }
+        // Add new versions from the new lockfile
+        for (const [key, oldPackage] of oldPackages.entries()) {
+          const newPackage = newPackages.get(key);
+          if (newPackage) {
+            oldPackage.newValue = newPackage.currentVersion;
+            oldPackage.newVersion = newPackage.currentVersion;
+          }
+        }
+      } catch {
+        logger.debug(`Error parsing lockfile: ${result.file.path}`);
+      }
+    }
+  }
+  // include only packages where the version has changed
+  const updatedPackages = Array.from(oldPackages.values()).filter(
+    (pkg) => pkg.newVersion && pkg.currentVersion !== pkg.newVersion,
+  );
+
+  return updatedPackages;
+}
+
+export async function createVulnerabilities(
+  packages: PackageDependency[],
+  rpmVulns: RpmVulnerabilities,
+): Promise<Vulnerability[]> {
+  const dummyPackageFileConfig = {
+    packageFile: 'dummy.spec',
+    deps: [],
+    manager: 'rpm-lockfile',
+    datasource: 'rpm-lockfile',
+  };
+
+  const queue = packages.map(
+    (pkg) => (): Promise<DependencyVulnerabilities | null> =>
+      rpmVulns.fetchDependencyVulnerability(dummyPackageFileConfig, pkg, true),
+  );
+
+  const results = await p.all(queue);
+  const filteredResults = results.filter(is.truthy);
+  const allVulnerabilities = filteredResults.flatMap(
+    (result) => result.vulnerabilities,
+  );
+  const uniqueVulnerabilities = Array.from(
+    new Map(
+      allVulnerabilities.map((vuln) => [vuln.vulnerability.id, vuln]),
+    ).values(),
+  );
+
+  return uniqueVulnerabilities;
+}
+
+export function applyVulnerabilityPRNotes(
+  vulnerabilities: Vulnerability[],
+  config: BranchConfig,
+  rpmVulns: RpmVulnerabilities,
+): void {
+  // this function is called multiple times for each lockfile in a PR, so we don't know
+  // the final number of vulnerabilities in each isolated run. This can create a side
+  // effect where first few vulnerabilities will have a description but the rest won't.
+
+  const truncated =
+    vulnerabilities.length + (config.upgrades[0].prBodyNotes?.length ?? 0) > 10;
+  const prBodyNotesList: string[] = [];
+
+  for (const vulnerability of vulnerabilities) {
+    const prBodyNotes = rpmVulns.generatePrBodyNotes(
+      vulnerability.vulnerability,
+      vulnerability.affected,
+      truncated,
+      false,
+    );
+
+    prBodyNotesList.push(...prBodyNotes);
+  }
+
+  config.prBodyNotes = [...(config.prBodyNotes ?? []), ...prBodyNotesList];
+  config.upgrades[0].prBodyNotes = [
+    ...(config.upgrades[0].prBodyNotes ?? []),
+    ...prBodyNotesList,
+  ];
 }


### PR DESCRIPTION
The new code parses the lockfiles, searches for fixed CVEs, and updates the PR body notes. For the latter two tasks, existing functions fetchDependencyVulnerability and generatePrBodyNotes are used. The only change is that fetchDependencyVulnerability is now able to filter out the vulnerabilities if newVersion is lower than fixed version. If no vulnerabilities are found or the lockfiles cannot be properly parsed, the branch is treated as a no-op and no PR is created/updated.

Few other changes were made as well:
- Renovate was updated to the latest upstream.
- for RPM security branches, rebaseCheck was swapped for forceRebase. Using this approach is cleaner and works even with closed PRs.
- Default PR name for RPM LockfileMaintenance has been changed to differentiate it from other managers

The implementation has been tested for the following scenarios and seems to work correctly:
- If proposed change fixes any CVEs, security PR is created
- If the lockfile has changed but no CVEs are fixed, security PR is not created
- If configured, multiple security PRs can be created, each for a different lockfile. Each one is evaluated separately.
- If one security PR changes multiple lockfiles, the fixed vulnerabilities are merged in the PR notes
- If multiple lockfiles are changed in one PR, but only some of them fix CVEs, only those that fix the CVEs are included in the PR
- Old or new lockfile parsing has failed. Security PR is not created
- Lockfile is up-to-date, no update can be proposed. Post-processing workflow is not run and a security PR is not created
- Open security PR is closed. New one is created in the next run.
- Security PR is merged. New one is created in the next run if there are new updates.
- Security PR is open and the lockfile in the base branch has changed. The PR is rebased to the base branch in the next run.
- Security PR is open and the nedb CVE file now has more entries. PR notes are updated accordingly
- Security PR is open and a new dependency is updated in the next run. If this update fixes a CVE, PR notes are updated accordingly
- Security and non-security RPM PRs can coexist simultaneously and don't interfere with each other
- If there are multiple base branches, multiple security PRs are created
- If a new version is lower than the fixedVersion from the CVE, this vulnerability fix is excluded from the final PR.

There are following known issues with this implementation:
- Security PRs will be open simultaneously with non-security PRs. I think this would be very difficult to fix and it also happens in other ecosystems so I don't see it as a big deal. We can also control the frequency with which non-security PRs get created.
- If one of security or nonsecurity PRs get merged, the other one doesn't get cleaned up automatically. This could be difficult to achieve as well and I think other ecosystems behave the same way. Our instance of renovate generally doesn't clean up stale content so I think this limitation is acceptable.

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number. -->
<!-- If you're referencing an issue with this pull request, put it in a Markdown list like this: - #issue_number. -->

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
