### PR TITLE
Prevent simultaneous processing of RPM branch pairs

### DIFF
--- a/lib/workers/repository/process/rpm-vuln-branches.spec.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.spec.ts
@@ -63,7 +63,9 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     expect(resultBranches).toHaveLength(2);
     expect(branchNames).toHaveLength(2);
     expect(branchNames).toEqual(resultBranches.map((b) => b.branchName));
-    const vulnBranch = resultBranches[1];
+
+    // Vulnerability branch is inserted BEFORE the original branch
+    const vulnBranch = resultBranches[0];
     expect(vulnBranch.branchName).toBe(
       'rpm-lockfile-maintenance-vulnerability',
     );
@@ -87,7 +89,75 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     expect(vulnBranch.vulnerabilityFixStrategy).toBe('lowest');
     expect(vulnBranch.upgrades[0].vulnerabilityFixStrategy).toBe('lowest');
 
-    const origBranch = resultBranches[0];
+    // Verify schedule is cleared
+    expect(vulnBranch.schedule).toEqual([]);
+    expect(vulnBranch.upgrades[0].schedule).toEqual([]);
+
+    // Original branch is now at index 1
+    const origBranch = resultBranches[1];
     expect(origBranch).toEqual(baseBranch);
+  });
+
+  it('handles multiple rpm-lockfile maintenance branches', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const branch1 = { ...baseBranch, branchName: 'rpm-lockfile-maintenance-1' };
+    const branch2 = { ...baseBranch, branchName: 'rpm-lockfile-maintenance-2' };
+    const nonRpmBranch = {
+      ...baseBranch,
+      manager: 'npm',
+      isLockFileMaintenance: false,
+    };
+    const branches = [branch1, nonRpmBranch, branch2];
+
+    const [resultBranches, branchNames] =
+      createRPMLockFileVulnerabilityBranches(branches, config);
+
+    expect(resultBranches).toHaveLength(5); // 2 vuln + 3 original
+    expect(branchNames).toHaveLength(5);
+    expect(branchNames).toEqual(resultBranches.map((b) => b.branchName));
+
+    // First vulnerability branch should be inserted before first original branch
+    expect(resultBranches[0].branchName).toBe(
+      'rpm-lockfile-maintenance-1-vulnerability',
+    );
+    expect(resultBranches[1].branchName).toBe('rpm-lockfile-maintenance-1');
+
+    // Non-RPM branch should be at index 2
+    expect(resultBranches[2]).toBe(nonRpmBranch);
+
+    // Second vulnerability branch should be inserted before second original branch
+    expect(resultBranches[3].branchName).toBe(
+      'rpm-lockfile-maintenance-2-vulnerability',
+    );
+    expect(resultBranches[4].branchName).toBe('rpm-lockfile-maintenance-2');
+  });
+
+  it('preserves original branch properties unchanged', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const originalBranch = {
+      ...baseBranch,
+      schedule: ['after 2am'],
+      customProperty: 'should-be-preserved',
+    };
+    const branches = [originalBranch];
+
+    const [resultBranches] = createRPMLockFileVulnerabilityBranches(
+      branches,
+      config,
+    );
+
+    const vulnBranch = resultBranches[0];
+    const preservedOriginalBranch = resultBranches[1];
+
+    // Original branch should be completely unchanged
+    expect(preservedOriginalBranch).toEqual(originalBranch);
+    expect(preservedOriginalBranch.schedule).toEqual(['after 2am']);
+    expect((preservedOriginalBranch as any).customProperty).toBe(
+      'should-be-preserved',
+    );
+
+    // Vulnerability branch should have modified properties
+    expect(vulnBranch.schedule).toEqual([]);
+    expect(vulnBranch.isVulnerabilityAlert).toBe(true);
   });
 });

--- a/lib/workers/repository/process/rpm-vuln-branches.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.ts
@@ -26,23 +26,35 @@ export function createRPMLockFileVulnerabilityBranches(
     const copiedBranch = clone(branch);
     // change some settings to make the it a vulnerability branch
     copiedBranch.schedule = [];
-    copiedBranch.upgrades[0].schedule = [];
     copiedBranch.branchName = `${branch.branchName}-vulnerability`;
-    copiedBranch.upgrades[0].branchName = `${branch.branchName}-vulnerability`;
     copiedBranch.branchTopic = `${branch.branchTopic}-vulnerability`;
-    copiedBranch.upgrades[0].branchTopic = `${branch.branchTopic}-vulnerability`;
     copiedBranch.commitMessage = `${branch.commitMessage} [SECURITY]`;
-    copiedBranch.upgrades[0].commitMessageSuffix = '[SECURITY]';
     copiedBranch.commitMessageSuffix = '[SECURITY]';
     copiedBranch.prTitle = `${branch.prTitle} [SECURITY]`;
     copiedBranch.isVulnerabilityAlert = true;
-    copiedBranch.upgrades[0].isVulnerabilityAlert = true;
     copiedBranch.vulnerabilitySeverity = 'UNKNOWN';
-    copiedBranch.upgrades[0].vulnerabilitySeverity = 'UNKNOWN';
     copiedBranch.vulnerabilityFixStrategy = 'lowest';
-    copiedBranch.upgrades[0].vulnerabilityFixStrategy = 'lowest';
 
-    resultBranches.push(copiedBranch);
+    // Set properties for all upgrades
+    for (const upgrade of copiedBranch.upgrades) {
+      upgrade.schedule = [];
+      upgrade.branchName = `${branch.branchName}-vulnerability`;
+      upgrade.branchTopic = `${branch.branchTopic}-vulnerability`;
+      upgrade.commitMessageSuffix = '[SECURITY]';
+      upgrade.isVulnerabilityAlert = true;
+      upgrade.vulnerabilitySeverity = 'UNKNOWN';
+      upgrade.vulnerabilityFixStrategy = 'lowest';
+    }
+
+    // Add the vulnerability branch BEFORE the original branch
+    const originalBranchIndex = resultBranches.findIndex(
+      (resultBranch) => resultBranch.branchName === branch.branchName,
+    );
+    if (originalBranchIndex === -1) {
+      resultBranches.push(copiedBranch);
+    } else {
+      resultBranches.splice(originalBranchIndex, 0, copiedBranch);
+    }
   }
   const branchNames = resultBranches.map((branch) => branch.branchName);
   return [resultBranches, branchNames];

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -258,8 +258,17 @@ export async function ensurePr(
 
   // Get changelog and then generate template strings
   for (const upgrade of upgrades) {
-    // TODO: types (#22198)
-    const upgradeKey = `${upgrade.depType!}-${upgrade.depName!}-${upgrade.manager}-${upgrade.currentVersion ?? ''}-${upgrade.currentValue ?? ''}-${upgrade.newVersion ?? ''}-${upgrade.newValue ?? ''}`;
+    let upgradeKey: string;
+    if (
+      config.manager === 'rpm-lockfile' &&
+      config.isLockFileMaintenance &&
+      config.isVulnerabilityAlert
+    ) {
+      upgradeKey = `${upgrade.packageFile!}-${upgrade.depType!}-${upgrade.depName!}-${upgrade.manager}-${upgrade.currentVersion ?? ''}-${upgrade.currentValue ?? ''}-${upgrade.newVersion ?? ''}-${upgrade.newValue ?? ''}`;
+    } else {
+      // TODO: types (#22198)
+      upgradeKey = `${upgrade.depType!}-${upgrade.depName!}-${upgrade.manager}-${upgrade.currentVersion ?? ''}-${upgrade.currentValue ?? ''}-${upgrade.newVersion ?? ''}-${upgrade.newValue ?? ''}`;
+    }
     if (processedUpgrades.includes(upgradeKey)) {
       continue;
     }


### PR DESCRIPTION
The biggest issue of the new approach of RPM vulnerabilities is that vulnerability and normal branches are handled separately. This keeps the implementation clean and significantly reduces the risk of issues, but has a side effect that security and non-security PRs will always be open simultaneously, confusing the users. This commit significantly improves the issue by preventing the normal PR to be processed if a valid corresponding security PR is detected. It's also able to handle partial PRs - if there are multiple lockfiles and only one has a security fix (security PR will only contain that one), normal PR is still created to ensure that no updates are blocked by the security PR. It should be noted that this change doesn't handle the scenario where a normal PR is already open and a new security fix is detected. In this case, the normal PR stays open. This can perhaps be fixed in the future by enabling prunestalebranches and implementing new logic.

The functionality was achieved by checking PRbodyNotes of the corresponding security PR. If the notes of all its upgrades (lockfiles) are non-empty, it indicates a full security update and the normal PR is set to an impossible cron schedule, being skipped. To support this new condition, upgrades are now properly handled in the post-processing code.

Jira: CLOUDDST-28764