### PR TITLE
Only propose RPM updates if there are any version changes

### DIFF
--- a/lib/workers/repository/update/branch/get-updated.ts
+++ b/lib/workers/repository/update/branch/get-updated.ts
@@ -17,7 +17,7 @@ import type { FileAddition, FileChange } from '../../../../util/git/types';
 import { coerceString } from '../../../../util/string';
 import type { BranchConfig, BranchUpgradeConfig } from '../../../types';
 import { doAutoReplace } from './auto-replace';
-import { postProcessRPMVulnerabilities } from './rpm-vuln-post-processing';
+import { postProcessRPMs } from './rpm-post-processing';
 
 export interface PackageFilesResult {
   artifactErrors: ArtifactError[];
@@ -500,12 +500,8 @@ export async function managerUpdateArtifacts(
   }
 
   const result = await updateArtifacts(updateArtifact);
-  if (
-    manager === 'rpm-lockfile' &&
-    config.isLockFileMaintenance &&
-    config.isVulnerabilityAlert
-  ) {
-    return postProcessRPMVulnerabilities(result, config);
+  if (manager === 'rpm-lockfile' && config.isLockFileMaintenance) {
+    return postProcessRPMs(result, config);
   } else {
     return result;
   }

--- a/lib/workers/repository/update/branch/rpm-post-processing.ts
+++ b/lib/workers/repository/update/branch/rpm-post-processing.ts
@@ -14,11 +14,11 @@ import type {
   Vulnerability,
 } from '../../process/types';
 
-export async function postProcessRPMVulnerabilities(
+export async function postProcessRPMs(
   result: UpdateArtifactsResult[] | null,
   config: BranchConfig,
 ): Promise<UpdateArtifactsResult[] | null> {
-  logger.debug('RPM vulnerability post-processing');
+  logger.debug('RPM lockfile maintenance post-processing');
   const upgrade = getUpgrade(result, config);
   if (result === null) {
     logger.debug('No RPM updates have been proposed');
@@ -29,6 +29,11 @@ export async function postProcessRPMVulnerabilities(
   if (packages.length === 0) {
     logger.warn('No RPM packages could be parsed');
     return null;
+  }
+
+  // skipping the rest of the logic if it's not a vulnerability alert
+  if (!config.isVulnerabilityAlert) {
+    return result;
   }
 
   const rpmVulnerabilities = await RpmVulnerabilities.create();


### PR DESCRIPTION
Apparently, rpm-lockfile-prototype can propose updates where only checksum and size have changed but the evr remains the same. These updates seem to be undesirable, so modify the code so that if no version changes are detected in a lockfile, treat the update as a no-op. This effectively stops such PRs from being created.

This change requires the post-processing workflow to be ran not just on the RPM vulnerability branches, but on regular RPM branches as well. Doing this allows us to make other modification to all RPM updates, for example adding a table of updates.

Jira: CLOUDDST-29578