### PR TITLE
Enable automerge of RPM vulnerability PRs based on severity

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2204,6 +2204,15 @@ const options: RenovateOptions[] = [
     experimentalIssues: [20542],
   },
   {
+    name: 'rpmVulnerabilityAutomerge',
+    description:
+      'Set at what criticality level should RPM vulnerability PRs be automerged.',
+    type: 'string',
+    default: null,
+    experimental: true,
+    allowedValues: ['ALL', 'MEDIUM', 'HIGH', 'CRITICAL'],
+  },
+  {
     name: 'pruneBranchAfterAutomerge',
     description: 'Set to `true` to enable branch pruning after automerging.',
     type: 'boolean',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -22,6 +22,12 @@ export type RepositoryCacheConfig = 'disabled' | 'enabled' | 'reset';
 export type RepositoryCacheType = 'local' | string;
 export type DryRunConfig = 'extract' | 'lookup' | 'full';
 export type RequiredConfig = 'required' | 'optional' | 'ignored';
+export type RPMVulnerabilityAutomerge =
+  | 'ALL'
+  | 'MEDIUM'
+  | 'HIGH'
+  | 'CRITICAL'
+  | null;
 
 export interface GroupConfig extends Record<string, unknown> {
   branchName?: string;
@@ -299,6 +305,7 @@ export interface RenovateConfig
   osvVulnerabilityAlerts?: boolean;
   containerVulnerabilityAlerts?: boolean;
   rpmVulnerabilityAlerts?: boolean;
+  rpmVulnerabilityAutomerge?: RPMVulnerabilityAutomerge;
   vulnerabilitySeverity?: string;
   customManagers?: CustomManager[];
   customDatasources?: Record<string, CustomDatasourceConfig>;

--- a/lib/util/vulnerability/utils.ts
+++ b/lib/util/vulnerability/utils.ts
@@ -1,4 +1,4 @@
-const severityOrder: Record<string, number> = {
+export const severityOrder: Record<string, number> = {
   LOW: 1,
   MEDIUM: 2,
   MODERATE: 2,

--- a/lib/workers/repository/process/rpm-vuln-branches.spec.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.spec.ts
@@ -21,7 +21,6 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
         schedule: ['after 1am'],
         commitMessageSuffix: '',
         isVulnerabilityAlert: false,
-        vulnerabilitySeverity: undefined,
         vulnerabilityFixStrategy: undefined,
       },
     ],
@@ -30,7 +29,6 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     commitMessageSuffix: '',
     prTitle: 'chore: rpm lockfile maintenance',
     isVulnerabilityAlert: false,
-    vulnerabilitySeverity: undefined,
     vulnerabilityFixStrategy: undefined,
   };
 
@@ -84,8 +82,6 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     );
     expect(vulnBranch.isVulnerabilityAlert).toBe(true);
     expect(vulnBranch.upgrades[0].isVulnerabilityAlert).toBe(true);
-    expect(vulnBranch.vulnerabilitySeverity).toBe('UNKNOWN');
-    expect(vulnBranch.upgrades[0].vulnerabilitySeverity).toBe('UNKNOWN');
     expect(vulnBranch.vulnerabilityFixStrategy).toBe('lowest');
     expect(vulnBranch.upgrades[0].vulnerabilityFixStrategy).toBe('lowest');
 
@@ -159,5 +155,36 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     // Vulnerability branch should have modified properties
     expect(vulnBranch.schedule).toEqual([]);
     expect(vulnBranch.isVulnerabilityAlert).toBe(true);
+  });
+
+  it('sets rpmVulnerabilityAutomerge from config', () => {
+    const config: RenovateConfig = {
+      rpmVulnerabilityAlerts: true,
+      rpmVulnerabilityAutomerge: 'HIGH',
+    } as any;
+    const branches = [baseBranch];
+
+    const [resultBranches] = createRPMLockFileVulnerabilityBranches(
+      branches,
+      config,
+    );
+
+    const vulnBranch = resultBranches[0];
+    expect(vulnBranch.rpmVulnerabilityAutomerge).toBe('HIGH');
+  });
+
+  it('sets rpmVulnerabilityAutomerge to undefined when config is undefined', () => {
+    const config: RenovateConfig = {
+      rpmVulnerabilityAlerts: true,
+    } as any;
+    const branches = [baseBranch];
+
+    const [resultBranches] = createRPMLockFileVulnerabilityBranches(
+      branches,
+      config,
+    );
+
+    const vulnBranch = resultBranches[0];
+    expect(vulnBranch.rpmVulnerabilityAutomerge).toBe(undefined);
   });
 });

--- a/lib/workers/repository/process/rpm-vuln-branches.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.ts
@@ -32,8 +32,8 @@ export function createRPMLockFileVulnerabilityBranches(
     copiedBranch.commitMessageSuffix = '[SECURITY]';
     copiedBranch.prTitle = `${branch.prTitle} [SECURITY]`;
     copiedBranch.isVulnerabilityAlert = true;
-    copiedBranch.vulnerabilitySeverity = 'UNKNOWN';
     copiedBranch.vulnerabilityFixStrategy = 'lowest';
+    copiedBranch.rpmVulnerabilityAutomerge = config.rpmVulnerabilityAutomerge;
 
     // Set properties for all upgrades
     for (const upgrade of copiedBranch.upgrades) {
@@ -42,7 +42,6 @@ export function createRPMLockFileVulnerabilityBranches(
       upgrade.branchTopic = `${branch.branchTopic}-vulnerability`;
       upgrade.commitMessageSuffix = '[SECURITY]';
       upgrade.isVulnerabilityAlert = true;
-      upgrade.vulnerabilitySeverity = 'UNKNOWN';
       upgrade.vulnerabilityFixStrategy = 'lowest';
     }
 

--- a/lib/workers/repository/process/rpm-vulnerabilities.ts
+++ b/lib/workers/repository/process/rpm-vulnerabilities.ts
@@ -626,7 +626,7 @@ export class RpmVulnerabilities {
     return [sanitizeMarkdown(content)];
   }
 
-  private extractSeverityDetails(
+  public extractSeverityDetails(
     vulnerability: Osv.Vulnerability,
     affected: Osv.Affected,
   ): SeverityDetails {

--- a/lib/workers/types.ts
+++ b/lib/workers/types.ts
@@ -2,6 +2,7 @@ import type { Merge } from 'type-fest';
 import type {
   GroupConfig,
   LegacyAdminConfig,
+  RPMVulnerabilityAutomerge,
   RenovateConfig,
   RenovateSharedConfig,
   ValidationMessage,
@@ -127,6 +128,7 @@ export interface BranchConfig
   automergeComment?: string;
   automergeType?: string;
   automergedPreviously?: boolean;
+  rpmVulnerabilityAutomerge?: RPMVulnerabilityAutomerge;
   baseBranch: string;
   errors?: ValidationMessage[];
   hasTypes?: boolean;


### PR DESCRIPTION
A weakness of the new RPM implementation is that it's impossible to configure the RPM vulnerability branches separately. This means that the automerge config[1] will not work for these branches. To enable this functionality, a more complex approach had to be implemented.

A new config option, rpmVulnerabilityAutomerge has been added, which users can set to enable RPM vulnerability automerge based on the CVE severity. This config option is added to the RPM vulnerability branchconfig and a new logic has been added to determine the highest CVE severity in a PR. If the severity is at least as high as configured, the PR is marked for automerge.

[1] https://github.com/konflux-ci/mintmaker-presets/blob/main/cve-automerge-critical.json

Docs PR: https://github.com/konflux-ci/docs/pull/457
Jira: CLOUDDST-29554