### PR TITLE
Fix regression of ENV variable propagation to rpm-lockfile-prototype

### DIFF
--- a/lib/modules/manager/rpm-lockfile/artifacts.ts
+++ b/lib/modules/manager/rpm-lockfile/artifacts.ts
@@ -48,7 +48,14 @@ export async function updateArtifacts({
     // and lockFileName already contain the (optional) subfolder.
     // Setting cwdFile would descend into that subfolder and
     // we'd have it set twice.
-    const execOptions: ExecOptions = {};
+    const execOptions: ExecOptions = {
+      extraEnv: {
+        DNF_VAR_SSL_CLIENT_KEY: process.env.DNF_VAR_SSL_CLIENT_KEY,
+        DNF_VAR_SSL_CLIENT_CERT: process.env.DNF_VAR_SSL_CLIENT_CERT,
+        DNF_VAR_SSL_AUTH_CLIENT_KEY: process.env.DNF_VAR_SSL_AUTH_CLIENT_KEY,
+        DNF_VAR_SSL_AUTH_CLIENT_CERT: process.env.DNF_VAR_SSL_AUTH_CLIENT_CERT,
+      },
+    };
 
     await exec(cmd, execOptions);
 


### PR DESCRIPTION
The propagation of these variables was not carried over to the new manager, rpm-lockfile-prototype. Add these variables to the new manager as well. Two new variables are added, which will be for the new use-case of repositories that require SSL cert authentication.
