### PR TITLE
Allow the use of pruneStaleBranches with MintMaker architecture

### DIFF
--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -2213,6 +2213,13 @@ const options: RenovateOptions[] = [
     allowedValues: ['ALL', 'MEDIUM', 'HIGH', 'CRITICAL'],
   },
   {
+    name: 'parallelRunPruneStaleBranches',
+    description:
+      'Set to `true` to enable an alternative approach to pruning stale branches. In this approach, Renovate will only prune stale branches belonging to the one base branch it is renovating. pruneStaleBranches must be enabled for this to have any effect.',
+    type: 'boolean',
+    default: false,
+  },
+  {
     name: 'pruneBranchAfterAutomerge',
     description: 'Set to `true` to enable branch pruning after automerging.',
     type: 'boolean',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -306,6 +306,7 @@ export interface RenovateConfig
   containerVulnerabilityAlerts?: boolean;
   rpmVulnerabilityAlerts?: boolean;
   rpmVulnerabilityAutomerge?: RPMVulnerabilityAutomerge;
+  parallelRunPruneStaleBranches?: boolean;
   vulnerabilitySeverity?: string;
   customManagers?: CustomManager[];
   customDatasources?: Record<string, CustomDatasourceConfig>;

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -160,6 +160,27 @@ export async function pruneStaleBranches(
     logger.debug('No renovate branches found');
     return;
   }
+
+  if (config.parallelRunPruneStaleBranches) {
+    logger.debug('Filtering stale branches to only belong to the base branch');
+    const baseBranch = branchList?.[0]?.split('/')[2] ?? null;
+    if (typeof baseBranch === 'string') {
+      renovateBranches = renovateBranches.filter((branchName) => {
+        try {
+          const parts = branchName.split('/');
+          if (parts.length >= 3) {
+            const branchBaseName = parts[2];
+            return branchBaseName === baseBranch;
+          }
+          return true;
+        } catch {
+          // If unable to parse, keep it
+          return true;
+        }
+      });
+    }
+  }
+
   logger.debug(
     {
       branchList: branchList?.sort(),


### PR DESCRIPTION
Since MintMaker runs for each base branch separately, pruneStaleBranches had to be disabled because it closes PRs created for other base branches. This function works by comparing detected existing Renovate branches and branches that were processed in the Renovate run. All branches that belong to Renovate and were not processed are removed.

This logic can be easily modifed for multiple-parallel-runs architecture by including only those existing branches that push to the same base branch. This results in a Renovate run only cleaning up the branches that point to the same base branch. Base branch is included in each branch name, so the filtering is trivial.

A new config option was added that enables this functionality. If MintMaker ever changes its architecture, this option should be disabled since the pruning would no longer work correctly.
