### PR TITLE
Fix a bug with RPM updates table rendering

### DIFF
--- a/lib/workers/repository/update/branch/rpm-post-processing.ts
+++ b/lib/workers/repository/update/branch/rpm-post-processing.ts
@@ -33,11 +33,9 @@ export async function postProcessRPMs(
     return null;
   }
 
-  // Create and add updates table to PR header
-  createUpdatesTable(config, upgrade, packages);
-
   // skipping the rest of the logic if it's not a vulnerability alert
   if (!config.isVulnerabilityAlert) {
+    createUpdatesTable(config, upgrade, packages);
     return result;
   }
 
@@ -52,6 +50,8 @@ export async function postProcessRPMs(
     logger.debug('No RPM vulnerabilities found');
     return null;
   }
+
+  createUpdatesTable(config, upgrade, packages);
 
   applyVulnerabilityPRNotes(
     vulnerabilities,


### PR DESCRIPTION
Previously, the function to render the table would always get called, even if the lockfile would fix no vulnverabilties. This resulted in a bug where security PR bodies would contain update tables of lockfiles that were not included because they fixed no vulnerabilities. Modify the logic so that the function only gets called if it's certain that the lockfile will be included in the PR.
