### PR TITLE
Increase logging when fetching newDigest for docker image updates

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -126,6 +126,19 @@ export class DockerDatasource extends Datasource {
         noAuth: true,
         cacheProvider: memCacheProvider,
       });
+
+      if (manifestResponse) {
+        logger.debug(
+          {
+            registryHost,
+            dockerRepository,
+            tag,
+            mode,
+            headers: manifestResponse.headers,
+          },
+          'Got manifest response from getManifestResponse() call.',
+        );
+      }
       return manifestResponse;
     } catch (err) /* istanbul ignore next */ {
       if (err instanceof ExternalHostError) {
@@ -919,6 +932,13 @@ export class DockerDatasource extends Datasource {
           digest =
             (manifestResponse.headers['docker-content-digest'] as string) ||
             null;
+
+          if (digest === null) {
+            logger.debug(
+              { registryHost, dockerRepository, newTag, packageName },
+              `No digest found in manifest response headers for package ${packageName} in getDigest() call.`,
+            );
+          }
         }
       }
 

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -682,10 +682,52 @@ export async function lookupUpdates(
           }
 
           // TODO #22198
-          update.newDigest ??=
-            dependency?.releases.find((r) => r.version === update.newValue)
-              ?.newDigest ??
-            (await getDigest(getDigestConfig, update.newValue))!;
+          update.newDigest ??= dependency?.releases.find(
+            (r) => r.version === update.newValue,
+          )?.newDigest;
+
+          if (update.newDigest === undefined || update.newDigest === null) {
+            logger.debug(
+              {
+                packageName: config.packageName,
+                currentValue: config.currentValue,
+                datasource: config.datasource,
+                newValue: update.newValue,
+                bucket: update.bucket,
+              },
+              'update.newDigest is undefined or null, releases did not have a digest, fetching digest from getDigest.',
+            );
+          }
+
+          update.newDigest ??= (await getDigest(
+            getDigestConfig,
+            update.newValue,
+          ))!;
+
+          if (update.newDigest === undefined || update.newDigest === null) {
+            logger.debug(
+              {
+                packageName: config.packageName,
+                currentValue: config.currentValue,
+                datasource: config.datasource,
+                newValue: update.newValue,
+                bucket: update.bucket,
+              },
+              'update.newDigest is still undefined or null, getDigest returned undefined or null.',
+            );
+          } else {
+            logger.debug(
+              {
+                packageName: config.packageName,
+                currentValue: config.currentValue,
+                datasource: config.datasource,
+                newValue: update.newValue,
+                bucket: update.bucket,
+                newDigest: update.newDigest,
+              },
+              'update.newDigest is defined, getDigest returned a digest.',
+            );
+          }
 
           // If the digest could not be determined, report this as otherwise the
           // update will be omitted later on without notice.


### PR DESCRIPTION
This patch is intended for use in staging to debug the long standing problems `Could not determine new digest for update`.

Example of the problematic PR can be found here: https://github.com/staticf0x/mintmaker-test/pull/182

In the dependency dashboard https://github.com/staticf0x/mintmaker-test/issues/187 you can see the amount of edits - each MM run different packages fail.

I will revert this PR when (or **if** :smile:) I find the root cause.