### PR TITLE
Fix image architecture when architecture is an empty string

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -943,7 +943,7 @@ export class DockerDatasource extends Datasource {
       }
 
       if (
-        isString(architecture) ||
+        isNonEmptyString(architecture) ||
         (manifestResponse &&
           !hasKey('docker-content-digest', manifestResponse.headers))
       ) {


### PR DESCRIPTION
Because the tekton tasks employed by Konflux have `architecture === ""`, we need this condition to check for a non-empty string, not just any string, because semantically in this case, an empty string is the same as `null`, in that "this image isn't supposed to run at all, so architecture is not provided". This PR needs to be tested on stage first, if it works, I'll try to contribute this patch to upstream as well.