### PR TITLE
feat: add requireTestsForPlatformAutomerge option

### DIFF
--- a/docs/usage/configuration-options.md
+++ b/docs/usage/configuration-options.md
@@ -4330,6 +4330,27 @@ For `npm` manager when `replacementApproach=alias` then instead of replacing `"f
 }
 ```
 
+## requireTestsForPlatformAutomerge
+
+When [`platformAutomerge`](#platformautomerge) is set to true (which is also the default state), Renovate will allow automerge immediately after creating a PR. However, you may want to ensure that at least one CI test check is present before allowing automerge.
+
+Use the `requireTestsForPlatformAutomerge` option to enforce this:
+
+```json
+{
+  "automerge": true,
+  "requireTestsForPlatformAutomerge": true
+}
+```
+
+When enabled:
+
+- Renovate will check if there are any test-related CI status checks or runs
+- If no test checks are found, PR will not be set to automerge immediately
+- Platforms that do not support retrieving status check names will skip this check gracefully
+
+This is useful to prevent accidental automerges when there is a delay between PR(MR) creation and the CI pipelines starting.
+
 ## respectLatest
 
 Similar to `ignoreUnstable`, this option controls whether to update to versions that are greater than the version tagged as `latest` in the repository.

--- a/lib/config/options/index.ts
+++ b/lib/config/options/index.ts
@@ -3167,6 +3167,14 @@ const options: RenovateOptions[] = [
     supportedPlatforms: ['azure', 'forgejo', 'gitea', 'github', 'gitlab'],
   },
   {
+    name: 'requireTestsForPlatformAutomerge',
+    description:
+      'Require at least one CI test status check to be present before allowing automerge.',
+    type: 'boolean',
+    default: false,
+    stage: 'branch',
+  },
+  {
     name: 'userStrings',
     description:
       'User-facing strings for the Renovate comment when a PR is closed.',

--- a/lib/config/types.ts
+++ b/lib/config/types.ts
@@ -98,6 +98,7 @@ export interface RenovateSharedConfig {
   repositoryCache?: RepositoryCacheConfig;
   repositoryCacheType?: RepositoryCacheType;
   respectLatest?: boolean;
+  requireTestsForPlatformAutomerge?: boolean;
   schedule?: string[];
   semanticCommitScope?: string | null;
   semanticCommitType?: string;

--- a/lib/modules/platform/github/index.ts
+++ b/lib/modules/platform/github/index.ts
@@ -1089,6 +1089,48 @@ async function getStatus(
   return status;
 }
 
+export async function getBranchStatusCheckNames(
+  branchName: string,
+): Promise<string[]> {
+  logger.debug(`getBranchStatusCheckNames(${branchName})`);
+  const checkNames: string[] = [];
+
+  try {
+    // Get commit statuses (old API)
+    const commitStatus = await getStatus(branchName);
+    if (commitStatus.statuses) {
+      checkNames.push(...commitStatus.statuses.map((status) => status.context));
+    }
+
+    // Get check runs (new API)
+    const checkRunsUrl = `repos/${config.repository}/commits/${escapeHash(
+      branchName,
+    )}/check-runs?per_page=100`;
+    const opts = {
+      headers: {
+        accept: 'application/vnd.github.antiope-preview+json',
+      },
+      paginate: true,
+      paginationField: 'check_runs',
+      cacheProvider: memCacheProvider,
+    };
+    const checkRunsRaw = (
+      await githubApi.getJsonUnchecked<{
+        check_runs: { name: string }[];
+      }>(checkRunsUrl, opts)
+    ).body;
+
+    if (checkRunsRaw.check_runs?.length) {
+      checkNames.push(...checkRunsRaw.check_runs.map((run) => run.name));
+    }
+  } catch (err) {
+    logger.debug({ err }, 'Error retrieving status check names');
+  }
+
+  logger.debug({ checkNames }, 'Retrieved status check names');
+  return checkNames;
+}
+
 // Returns the combined status for a branch.
 export async function getBranchStatus(
   branchName: string,

--- a/lib/modules/platform/gitlab/index.ts
+++ b/lib/modules/platform/gitlab/index.ts
@@ -410,6 +410,29 @@ async function getStatus(
   }
 }
 
+export async function getBranchStatusCheckNames(
+  branchName: string,
+): Promise<string[]> {
+  logger.debug(`getBranchStatusCheckNames(${branchName})`);
+  const checkNames: string[] = [];
+
+  try {
+    const branchStatuses = await getStatus(branchName);
+    if (branchStatuses && Array.isArray(branchStatuses)) {
+      checkNames.push(
+        ...branchStatuses
+          .map((status) => status.name)
+          .filter((name): name is string => !!name),
+      );
+    }
+  } catch (err) {
+    logger.debug({ err }, 'Error retrieving GitLab status check names');
+  }
+
+  logger.debug({ checkNames }, 'Retrieved GitLab status check names');
+  return checkNames;
+}
+
 const gitlabToRenovateStatusMapping: Record<BranchState, BranchStatus> = {
   pending: 'yellow',
   created: 'yellow',

--- a/lib/modules/platform/types.ts
+++ b/lib/modules/platform/types.ts
@@ -269,6 +269,7 @@ export interface Platform {
     // TODO: can be undefined or null ? #22198
     context: string | null | undefined,
   ): Promise<BranchStatus | null>;
+  getBranchStatusCheckNames?(branchName: string): Promise<string[]>;
   ensureCommentRemoval(
     ensureCommentRemoval:
       | EnsureCommentRemovalConfigByTopic

--- a/lib/util/ci-test-detection.spec.ts
+++ b/lib/util/ci-test-detection.spec.ts
@@ -1,0 +1,42 @@
+import { hasRelevantStatusChecks } from './ci-test-detection';
+
+describe('util/ci-test-detection', () => {
+  describe('hasRelevantStatusChecks', () => {
+    it('returns false for empty array', () => {
+      expect(hasRelevantStatusChecks([])).toBe(false);
+    });
+
+    it('returns false for null/undefined', () => {
+      expect(hasRelevantStatusChecks(null as any)).toBe(false);
+      expect(hasRelevantStatusChecks(undefined as any)).toBe(false);
+    });
+
+    it('returns true for test-related checks', () => {
+      expect(hasRelevantStatusChecks(['ci/test', 'build'])).toBe(true);
+      expect(hasRelevantStatusChecks(['GitHub Actions / test'])).toBe(true);
+      expect(hasRelevantStatusChecks(['lint', 'typecheck'])).toBe(true);
+    });
+
+    it('returns false for only excluded checks', () => {
+      expect(hasRelevantStatusChecks(['renovate/stability-days'])).toBe(false);
+      expect(hasRelevantStatusChecks(['codecov/patch'])).toBe(false);
+      expect(hasRelevantStatusChecks(['dependabot'])).toBe(false);
+      expect(hasRelevantStatusChecks(['vercel'])).toBe(false);
+      expect(hasRelevantStatusChecks(['netlify'])).toBe(false);
+    });
+
+    it('returns true when mix of excluded and relevant checks', () => {
+      expect(
+        hasRelevantStatusChecks(['renovate/stability-days', 'ci/test']),
+      ).toBe(true);
+      expect(
+        hasRelevantStatusChecks(['codecov/patch', 'build', 'vercel']),
+      ).toBe(true);
+    });
+
+    it('is case insensitive for exclusions', () => {
+      expect(hasRelevantStatusChecks(['Renovate/something'])).toBe(false);
+      expect(hasRelevantStatusChecks(['CODECOV/patch'])).toBe(false);
+    });
+  });
+});

--- a/lib/util/ci-test-detection.ts
+++ b/lib/util/ci-test-detection.ts
@@ -1,0 +1,44 @@
+import { logger } from '../logger';
+
+/**
+ * Patterns for CI status checks that are not test-related.
+ * These are excluded when determining if relevant CI checks exist.
+ */
+const nonTestStatusCheckPatterns = [
+  'renovate/',
+  'dependabot',
+  'codecov/',
+  'coveralls',
+  'vercel',
+  'netlify',
+  'chromatic',
+  'percy',
+  'snyk',
+  'fossa',
+  'mergify',
+  'bors',
+];
+
+/**
+ * Detects if any CI status check names appear to be relevant (non-excluded).
+ * Excludes known non-test services like Renovate, Codecov, Dependabot, etc.
+ */
+export function hasRelevantStatusChecks(checkNames: string[]): boolean {
+  if (!checkNames || checkNames.length === 0) {
+    return false;
+  }
+
+  const relevantChecks = checkNames.filter((name) => {
+    const lowerName = name.toLowerCase();
+    return !nonTestStatusCheckPatterns.some((pattern) =>
+      lowerName.includes(pattern),
+    );
+  });
+
+  logger.debug(
+    { checkNames, relevantChecks },
+    'hasRelevantStatusChecks evaluation',
+  );
+
+  return relevantChecks.length > 0;
+}

--- a/lib/workers/repository/config-migration/pr/index.ts
+++ b/lib/workers/repository/config-migration/pr/index.ts
@@ -103,7 +103,7 @@ ${
         prTitle,
         prBody,
         labels,
-        platformPrOptions: getPlatformPrOptions({
+        platformPrOptions: await getPlatformPrOptions({
           ...config,
           automerge: false,
         }),

--- a/lib/workers/repository/onboarding/pr/index.ts
+++ b/lib/workers/repository/onboarding/pr/index.ts
@@ -193,7 +193,7 @@ If you need any further assistance then you can also [request help here](${
         prTitle,
         prBody,
         labels,
-        platformPrOptions: getPlatformPrOptions({
+        platformPrOptions: await getPlatformPrOptions({
           ...config,
           automerge: false,
         }),

--- a/lib/workers/repository/update/branch/index.spec.ts
+++ b/lib/workers/repository/update/branch/index.spec.ts
@@ -140,7 +140,7 @@ describe('workers/repository/update/branch/index', () => {
           number: 5,
         }),
       });
-      prWorker.getPlatformPrOptions.mockReturnValue({
+      prWorker.getPlatformPrOptions.mockResolvedValue({
         usePlatformAutomerge: true,
       });
       GlobalConfig.set(adminConfig);
@@ -3058,7 +3058,7 @@ describe('workers/repository/update/branch/index', () => {
           state: 'open',
         }),
       );
-      prWorker.getPlatformPrOptions.mockReturnValue({
+      prWorker.getPlatformPrOptions.mockResolvedValue({
         usePlatformAutomerge: true,
       });
       GlobalConfig.set({ ...adminConfig, dryRun: 'full' });

--- a/lib/workers/repository/update/branch/index.ts
+++ b/lib/workers/repository/update/branch/index.ts
@@ -709,7 +709,7 @@ export async function processBranch(
     }
 
     if (branchPr) {
-      const platformPrOptions = getPlatformPrOptions(config);
+      const platformPrOptions = await getPlatformPrOptions(config);
       if (
         platformPrOptions.usePlatformAutomerge &&
         platform.reattemptPlatformAutomerge

--- a/lib/workers/repository/update/pr/index.spec.ts
+++ b/lib/workers/repository/update/pr/index.spec.ts
@@ -10,6 +10,7 @@ import { getPrBodyStruct } from '../../../../modules/platform/pr-body';
 import type { Pr } from '../../../../modules/platform/types';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
 import type { PrCache } from '../../../../util/cache/repository/types';
+import * as ciTestDetection from '../../../../util/ci-test-detection';
 import { fingerprint } from '../../../../util/fingerprint';
 import { toBase64 } from '../../../../util/string';
 import * as _limits from '../../../global/limits';
@@ -21,7 +22,7 @@ import type { ChangeLogChange, ChangeLogRelease } from './changelog/types';
 import * as _participants from './participants';
 import * as _prCache from './pr-cache';
 import { generatePrBodyFingerprintConfig } from './pr-fingerprint';
-import { ensurePr } from '.';
+import { ensurePr, getPlatformPrOptions } from '.';
 import { git, logger, partial, platform, scm } from '~test/util';
 
 vi.mock('../../changelog');
@@ -43,6 +44,9 @@ const comment = vi.mocked(_comment);
 
 vi.mock('./pr-cache');
 const prCache = vi.mocked(_prCache);
+
+vi.mock('../../../../util/ci-test-detection');
+const mockCiTestDetection = vi.mocked(ciTestDetection);
 
 describe('workers/repository/update/pr/index', () => {
   describe('ensurePr', () => {
@@ -1225,6 +1229,92 @@ describe('workers/repository/update/pr/index', () => {
         expect(logger.logger.debug).not.toHaveBeenCalledExactlyOnceWith(
           'PR cache not found',
         );
+      });
+    });
+  });
+  describe('getPlatformPrOptions', () => {
+    beforeEach(() => {
+      vi.resetAllMocks();
+    });
+
+    it('returns usePlatformAutomerge true when automerge enabled', async () => {
+      const result = await getPlatformPrOptions({
+        automerge: true,
+        automergeType: 'pr',
+        platformAutomerge: true,
+      } as any);
+      expect(result.usePlatformAutomerge).toBe(true);
+    });
+
+    it('returns usePlatformAutomerge false when automerge disabled', async () => {
+      const result = await getPlatformPrOptions({
+        automerge: false,
+        platformAutomerge: true,
+      } as any);
+      expect(result.usePlatformAutomerge).toBe(false);
+    });
+
+    describe('requireTestsForPlatformAutomerge', () => {
+      it('disables automerge when no CI checks found', async () => {
+        platform.getBranchStatusCheckNames = vi.fn().mockResolvedValue([]);
+        mockCiTestDetection.hasRelevantStatusChecks.mockReturnValue(false);
+
+        const result = await getPlatformPrOptions({
+          automerge: true,
+          automergeType: 'pr',
+          platformAutomerge: true,
+          requireTestsForPlatformAutomerge: true,
+          branchName: 'renovate/test',
+        } as any);
+
+        expect(result.usePlatformAutomerge).toBe(false);
+      });
+
+      it('enables automerge when CI checks found', async () => {
+        platform.getBranchStatusCheckNames = vi
+          .fn()
+          .mockResolvedValue(['ci/test']);
+        mockCiTestDetection.hasRelevantStatusChecks.mockReturnValue(true);
+
+        const result = await getPlatformPrOptions({
+          automerge: true,
+          automergeType: 'pr',
+          platformAutomerge: true,
+          requireTestsForPlatformAutomerge: true,
+          branchName: 'renovate/test',
+        } as any);
+
+        expect(result.usePlatformAutomerge).toBe(true);
+      });
+
+      it('enables automerge on error (fail-open)', async () => {
+        platform.getBranchStatusCheckNames = vi
+          .fn()
+          .mockRejectedValue(new Error('API error'));
+
+        const result = await getPlatformPrOptions({
+          automerge: true,
+          automergeType: 'pr',
+          platformAutomerge: true,
+          requireTestsForPlatformAutomerge: true,
+          branchName: 'renovate/test',
+        } as any);
+
+        expect(result.usePlatformAutomerge).toBe(true);
+      });
+
+      it('enables automerge when platform does not support getBranchStatusCheckNames', async () => {
+        (platform as any).getBranchStatusCheckNames = undefined;
+
+        const result = await getPlatformPrOptions({
+          automerge: true,
+          automergeType: 'pr',
+          platformAutomerge: true,
+          requireTestsForPlatformAutomerge: true,
+          branchName: 'renovate/test',
+        } as any);
+
+        expect(result.usePlatformAutomerge).toBe(true);
       });
     });
   });

--- a/lib/workers/repository/update/pr/index.ts
+++ b/lib/workers/repository/update/pr/index.ts
@@ -22,6 +22,7 @@ import {
 } from '../../../../modules/platform/pr-body';
 import { scm } from '../../../../modules/platform/scm';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
+import { hasRelevantStatusChecks } from '../../../../util/ci-test-detection';
 import { getElapsedHours } from '../../../../util/date';
 import { stripEmojis } from '../../../../util/emoji';
 import { fingerprint } from '../../../../util/fingerprint';
@@ -45,14 +46,51 @@ import {
 } from './pr-fingerprint';
 import { tryReuseAutoclosedPr } from './pr-reuse';
 
-export function getPlatformPrOptions(
+export async function getPlatformPrOptions(
   config: RenovateConfig & PlatformPrOptions,
-): PlatformPrOptions {
+): Promise<PlatformPrOptions> {
   const usePlatformAutomerge = Boolean(
     config.automerge &&
       (config.automergeType === 'pr' || config.automergeType === 'branch') &&
       config.platformAutomerge,
   );
+
+  // Only enable platform automerge if tests exist (when required)
+  if (usePlatformAutomerge && config.requireTestsForPlatformAutomerge) {
+    if (platform.getBranchStatusCheckNames && config.branchName) {
+      try {
+        const checkNames = await platform.getBranchStatusCheckNames(
+          config.branchName,
+        );
+        if (!hasRelevantStatusChecks(checkNames)) {
+          logger.debug(
+            'requireTestsForPlatformAutomerge: No CI tests found - delaying platform automerge',
+          );
+          return {
+            autoApprove: !!config.autoApprove,
+            automergeStrategy: config.automergeStrategy,
+            azureWorkItemId: config.azureWorkItemId ?? 0,
+            bbAutoResolvePrTasks: !!config.bbAutoResolvePrTasks,
+            bbUseDefaultReviewers: !!config.bbUseDefaultReviewers,
+            gitLabIgnoreApprovals: !!config.gitLabIgnoreApprovals,
+            forkModeDisallowMaintainerEdits:
+              !!config.forkModeDisallowMaintainerEdits,
+            usePlatformAutomerge: false,
+          };
+        }
+        logger.debug(
+          'requireTestsForPlatformAutomerge: CI tests found - enabling platform automerge',
+        );
+      } catch (err) {
+        logger.debug({ err }, 'Error checking for test status checks');
+        // On error, proceed with platform automerge anyway
+      }
+    } else {
+      logger.debug(
+        'Platform does not support getBranchStatusCheckNames - enabling platform automerge',
+      );
+    }
+  }
 
   return {
     autoApprove: !!config.autoApprove,
@@ -431,7 +469,7 @@ export async function ensurePr(
         number: existingPr.number,
         prTitle,
         prBody,
-        platformPrOptions: getPlatformPrOptions(config),
+        platformPrOptions: await getPlatformPrOptions(config),
       };
       // PR must need updating
       if (existingPr?.targetBranch !== config.baseBranch) {
@@ -535,7 +573,7 @@ export async function ensurePr(
           prTitle,
           prBody,
           labels: prepareLabels(config),
-          platformPrOptions: getPlatformPrOptions(config),
+          platformPrOptions: await getPlatformPrOptions(config),
           draftPR: !!config.draftPR,
           milestone: config.milestone,
         });


### PR DESCRIPTION
Prevents automerge race conditions where PRs are merged before CI tests have started running. When enabled, platform automerge is only set if test-related status checks are detected on the branch.

Implementation:
- Adds getBranchStatusCheckNames() to GitHub and GitLab platforms
- Filters out non-test checks (Renovate, Codecov, deployments, etc.)
- Delays platform automerge until relevant CI checks are present

This PR is meant to solve this ticket: [CWFHEALTH-4533](https://issues.redhat.com/browse/CWFHEALTH-4533)

Assisted-by: Cursor