### PR TITLE
Add support for private registries on rpm-lock manager

### DIFF
--- a/lib/modules/manager/rpm-lockfile/artifacts.spec.ts
+++ b/lib/modules/manager/rpm-lockfile/artifacts.spec.ts
@@ -3,7 +3,7 @@ import { mockExecAll } from '../../../../test/exec-util';
 import { fs } from '../../../../test/util';
 import { GlobalConfig } from '../../../config/global';
 import type { RepoGlobalConfig } from '../../../config/types';
-import * as fsUtils from '../../../util/fs';
+import * as hostRules from '../../../util/host-rules';
 import { updateArtifacts } from '.';
 
 vi.mock('../../../util/fs');
@@ -17,6 +17,7 @@ describe('modules/manager/rpm-lockfile/artifacts', () => {
   describe('updateArtifacts()', () => {
     beforeEach(() => {
       GlobalConfig.set(adminConfig);
+      hostRules.clear();
     });
 
     it('returns null if not in lockFileMaintenance', async () => {
@@ -36,7 +37,7 @@ describe('modules/manager/rpm-lockfile/artifacts', () => {
       const execSnapshots = mockExecAll();
 
       fs.readLocalFile.mockResolvedValue('Current rpms.lock.yaml');
-      vi.spyOn(fsUtils, 'getSiblingFileName').mockReturnValue('rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
 
       expect(
         await updateArtifacts({
@@ -61,7 +62,7 @@ describe('modules/manager/rpm-lockfile/artifacts', () => {
 
       fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
       fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
-      vi.spyOn(fsUtils, 'getSiblingFileName').mockReturnValue('rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
 
       expect(
         await updateArtifacts({
@@ -95,7 +96,7 @@ describe('modules/manager/rpm-lockfile/artifacts', () => {
 
       fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
       fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
-      vi.spyOn(fsUtils, 'getSiblingFileName').mockReturnValue('rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
 
       expect(
         await updateArtifacts({
@@ -122,6 +123,195 @@ describe('modules/manager/rpm-lockfile/artifacts', () => {
           cmd: 'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
         },
       ]);
+    });
+
+    it('generates skopeo login commands for docker hostRules', async () => {
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'quay.io/myorg',
+        username: 'testuser',
+        password: 'testpassword',
+      });
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'registry.redhat.io',
+        username: 'rhuser',
+        password: 'rhpassword',
+      });
+
+      const execSnapshots = mockExecAll();
+
+      fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
+      fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
+      fs.privateCacheDir.mockReturnValue(
+        '/tmp/renovate/cache/__renovate-private-cache',
+      );
+
+      await updateArtifacts({
+        packageFileName: 'rpms.in.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+      });
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'skopeo login --username testuser --password testpassword quay.io/myorg',
+        },
+        {
+          cmd: 'skopeo login --username rhuser --password rhpassword registry.redhat.io',
+        },
+        {
+          cmd: 'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
+        },
+      ]);
+    });
+
+    it('skips skopeo login for hostRules without credentials', async () => {
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'quay.io/myorg',
+        // No username/password
+      });
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'registry.redhat.io',
+        username: 'rhuser',
+        // No password
+      });
+
+      const execSnapshots = mockExecAll();
+
+      fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
+      fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
+
+      await updateArtifacts({
+        packageFileName: 'rpms.in.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+      });
+
+      // Only the main command, no skopeo logins
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
+        },
+      ]);
+    });
+
+    it('skips skopeo login for non-docker hostRules', async () => {
+      hostRules.add({
+        hostType: 'npm',
+        matchHost: 'registry.npmjs.org',
+        username: 'npmuser',
+        password: 'npmpassword',
+      });
+      hostRules.add({
+        hostType: 'helm',
+        matchHost: 'charts.example.com',
+        username: 'helmuser',
+        password: 'helmpassword',
+      });
+
+      const execSnapshots = mockExecAll();
+
+      fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
+      fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
+
+      await updateArtifacts({
+        packageFileName: 'rpms.in.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+      });
+
+      // Only the main command, no skopeo logins for non-docker hostRules
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
+        },
+      ]);
+    });
+
+    it('handles hostRules with https:// prefix in matchHost', async () => {
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'https://quay.io/myorg',
+        username: 'testuser',
+        password: 'testpassword',
+      });
+
+      const execSnapshots = mockExecAll();
+
+      fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
+      fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
+      fs.privateCacheDir.mockReturnValue(
+        '/tmp/renovate/cache/__renovate-private-cache',
+      );
+
+      await updateArtifacts({
+        packageFileName: 'rpms.in.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+      });
+
+      expect(execSnapshots).toMatchObject([
+        {
+          cmd: 'skopeo login --username testuser --password testpassword quay.io/myorg',
+        },
+        {
+          cmd: 'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
+        },
+      ]);
+    });
+
+    it('handles special characters in username and password', async () => {
+      hostRules.add({
+        hostType: 'docker',
+        matchHost: 'quay.io',
+        username: "user+special'name",
+        password: 'pass\'word$with"special',
+      });
+
+      const execSnapshots = mockExecAll();
+
+      fs.readLocalFile.mockResolvedValueOnce('Current rpms.lock.yaml');
+      fs.readLocalFile.mockResolvedValueOnce('New rpms.lock.yaml');
+      fs.getSiblingFileName.mockReturnValue('rpms.lock.yaml');
+      fs.privateCacheDir.mockReturnValue(
+        '/tmp/renovate/cache/__renovate-private-cache',
+      );
+
+      await updateArtifacts({
+        packageFileName: 'rpms.in.yaml',
+        updatedDeps: [],
+        newPackageFileContent: '',
+        config: {
+          updateType: 'lockFileMaintenance',
+        },
+      });
+
+      // The shlex quote function should properly escape special characters
+      expect(execSnapshots).toHaveLength(2);
+      expect(execSnapshots[0].cmd).toContain('skopeo login');
+      expect(execSnapshots[0].cmd).toContain('quay.io');
+      expect(execSnapshots[1].cmd).toBe(
+        'caching-rpm-lockfile-prototype rpms.in.yaml --outfile rpms.lock.yaml',
+      );
     });
   });
 });

--- a/lib/modules/manager/rpm-lockfile/artifacts.ts
+++ b/lib/modules/manager/rpm-lockfile/artifacts.ts
@@ -1,3 +1,5 @@
+import { quote } from 'shlex';
+import upath from 'upath';
 import { TEMPORARY_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { exec } from '../../../util/exec';
@@ -5,9 +7,46 @@ import type { ExecOptions } from '../../../util/exec/types';
 import {
   deleteLocalFile,
   getSiblingFileName,
+  privateCacheDir,
   readLocalFile,
 } from '../../../util/fs';
+import * as hostRules from '../../../util/host-rules';
+import { DockerDatasource } from '../../datasource/docker';
 import type { UpdateArtifact, UpdateArtifactsResult } from '../types';
+
+// Return the path to the skopeo auth file in the private cache directory.
+// This prevents credential leakage between repositories.
+function skopeoAuthFile(): string {
+  return upath.join(privateCacheDir(), 'skopeo-auth.json');
+}
+
+// Generate skopeo login commands for all docker hostRules with credentials.
+// This allows rpm-lockfile-prototype (which uses skopeo internally) to
+// authenticate to container registries.
+// Note: skopeo will use REGISTRY_AUTH_FILE env var set in execOptions.
+function generateSkopeoLoginCommands(): string[] {
+  const cmds: string[] = [];
+  const dockerHostRules = hostRules.findAll({ hostType: DockerDatasource.id });
+
+  logger.debug(
+    `Found ${dockerHostRules.length} docker host rule(s) for skopeo login`,
+  );
+
+  for (const rule of dockerHostRules) {
+    const { matchHost, username, password } = rule;
+
+    if (matchHost && username && password) {
+      const registry = matchHost.replace(/^https?:\/\//, '');
+      logger.debug(`Generating skopeo login for registry: ${registry}`);
+
+      cmds.push(
+        `skopeo login --username ${quote(username)} --password ${quote(password)} ${quote(registry)}`,
+      );
+    }
+  }
+
+  return cmds;
+}
 
 export async function updateArtifacts({
   packageFileName,
@@ -40,6 +79,10 @@ export async function updateArtifacts({
   try {
     await deleteLocalFile(lockFileName);
 
+    // Generate skopeo login commands for docker registries
+    const skopeoLoginCmds = generateSkopeoLoginCommands();
+    cmd.push(...skopeoLoginCmds);
+
     cmd.push(
       `caching-rpm-lockfile-prototype ${packageFileName} --outfile ${lockFileName}`,
     );
@@ -54,6 +97,10 @@ export async function updateArtifacts({
         DNF_VAR_SSL_CLIENT_CERT: process.env.DNF_VAR_SSL_CLIENT_CERT,
         DNF_VAR_SSL_AUTH_CLIENT_KEY: process.env.DNF_VAR_SSL_AUTH_CLIENT_KEY,
         DNF_VAR_SSL_AUTH_CLIENT_CERT: process.env.DNF_VAR_SSL_AUTH_CLIENT_CERT,
+        // Point skopeo/containers to use our private auth file (only if we have logins)
+        ...(skopeoLoginCmds.length > 0 && {
+          REGISTRY_AUTH_FILE: skopeoAuthFile(),
+        }),
       },
     };
 


### PR DESCRIPTION
MintMaker will generate the hostRules from the linked secrets, however rpm-lock will not use them. This PR follows the same pattern helm manager uses to skopeo login before running rpm-lock-prototype, allowing to support rpm refresh updates when the container base image is coming from a private registry

<!-- If this is your first pull request: sign the CLA with this GitHub app: https://cla-assistant.io/renovatebot/renovate -->
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->
<!-- Please read https://github.com/renovatebot/renovate/blob/main/.github/contributing.md before you create your pull request.-->

## Changes

<!-- Describe what behavior is changed by this PR. -->

## Context

Please select one of the below:

- [ ] This closes an existing Issue: #
- [ ] This doesn't close an Issue, but I accept the risk that this PR may be closed if maintainers disagree with its opening or implementation

## AI assistance disclosure

<!-- We request this information to assist reviewers in identifying AI-generated errors and other issues specific to AI usage. While we typically permit the use of AI tools, we appreciate being notified when they are employed. -->

Did you use AI tools to create any part of this pull request?

Please select one option and, if yes, briefly describe how AI was used (e.g., code, tests, docs) and which tool(s) you used.

- [ ] No — I did not use AI for this contribution.
- [ ] Yes — minimal assistance (e.g., IDE autocomplete, small code completions, grammar fixes).
- [ ] Yes — substantive assistance (AI generated non‑trivial portions of code, tests, or documentation).
- [ ] Yes — other (please describe):

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please select one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ ] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

The public repository: <URL>

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
