### PR TITLE
Modify Docker Datasource to parse manifest correctly

### DIFF
--- a/lib/modules/datasource/docker/schema.ts
+++ b/lib/modules/datasource/docker/schema.ts
@@ -106,6 +106,7 @@ export const DistributionManifest = ManifestObject.extend({
   config: Descriptor.extend({
     mediaType: z.literal('application/vnd.docker.container.image.v1+json'),
   }),
+  annotations: z.record(z.string()).nullish(),
 });
 export type DistributionManifest = z.infer<typeof DistributionManifest>;
 


### PR DESCRIPTION
Docker datasource parse the manifests from quay.io with DockerManifest Schema which doesn't have annotations at manifest level like OCIimageManifest.