### PR TITLE
Fix fetching tekton tasks changelogs

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -1243,6 +1243,15 @@ export class DockerDatasource extends Datasource {
       if (isNonEmptyString(labels[imageUrlLabel])) {
         ret.homepage = labels[imageUrlLabel];
       }
+      if (registryHost === 'https://quay.io') {
+        const packageNameAbsolute = packageName
+          .split('/')
+          .slice(-1)
+          .join('/')
+          .replace(/^task-/, '');
+        ret.changelogUrl = `${ret.sourceUrl}/blob/main/task/${packageNameAbsolute}/CHANGELOG.md`;
+        ret.sourceDirectory = `task/${packageNameAbsolute}`;
+      }
     }
     return ret;
   }


### PR DESCRIPTION
The docker datasource was not populating some variables. Now, with `changelogUrl, sourceDirectory` variables is being set. Renovate is able to fetch changelogs.
