### PR TITLE
fix: cache poisoning by invalid quay.io credentials

### DIFF
--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -32,6 +32,7 @@ import { ecrRegex, getECRAuthToken } from './ecr';
 import { googleRegex } from './google';
 import type { OciHelmConfig } from './schema';
 import type { RegistryRepository } from './types';
+import { QuayIOAuthError } from '../../../types/errors/quay-io-auth-error';
 
 export const dockerDatasourceId = 'docker';
 
@@ -221,7 +222,7 @@ export async function getAuthHeaders(
         { err, registryHost, dockerRepository },
         'quay.io getAuthHeaders error',
       );
-      return null;
+      throw new QuayIOAuthError('quay.io getAuthHeaders error');
     }
     /* v8 ignore if */
     if (err.statusCode === 401) {

--- a/lib/modules/datasource/docker/common.ts
+++ b/lib/modules/datasource/docker/common.ts
@@ -7,6 +7,7 @@ import {
 import { logger } from '../../../logger';
 import type { HostRule } from '../../../types';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
+import { QuayIOAuthError } from '../../../types/errors/quay-io-auth-error';
 import { coerceArray } from '../../../util/array';
 import { detectPlatform } from '../../../util/common';
 import { parseGitUrl } from '../../../util/git/url';
@@ -32,7 +33,6 @@ import { ecrRegex, getECRAuthToken } from './ecr';
 import { googleRegex } from './google';
 import type { OciHelmConfig } from './schema';
 import type { RegistryRepository } from './types';
-import { QuayIOAuthError } from '../../../types/errors/quay-io-auth-error';
 
 export const dockerDatasourceId = 'docker';
 

--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -3,6 +3,7 @@ import { GlobalConfig } from '../../../config/global';
 import { PAGE_NOT_FOUND_ERROR } from '../../../constants/error-messages';
 import { logger } from '../../../logger';
 import { ExternalHostError } from '../../../types/errors/external-host-error';
+import { QuayIOAuthError } from '../../../types/errors/quay-io-auth-error';
 import { cache } from '../../../util/cache/package/decorator';
 import { getEnv } from '../../../util/env';
 import { HttpError } from '../../../util/http';
@@ -154,6 +155,9 @@ export class DockerDatasource extends Datasource {
       }
       return manifestResponse;
     } catch (err) /* istanbul ignore next */ {
+      if (err instanceof QuayIOAuthError) {
+        throw err;
+      }
       if (err instanceof ExternalHostError) {
         throw err;
       }
@@ -1068,6 +1072,9 @@ export class DockerDatasource extends Datasource {
         logger.debug(`Got docker digest ${digest!}`);
       }
     } catch (err) /* istanbul ignore next */ {
+      if (err instanceof QuayIOAuthError) {
+        throw err;
+      }
       if (err instanceof ExternalHostError) {
         throw err;
       }

--- a/lib/types/errors/quay-io-auth-error.ts
+++ b/lib/types/errors/quay-io-auth-error.ts
@@ -1,0 +1,1 @@
+export class QuayIOAuthError extends Error {}

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -43,6 +43,7 @@ import {
   addReplacementUpdateIfValid,
   isReplacementRulesConfigured,
 } from './utils';
+import { QuayIOAuthError } from '../../../../types/errors/quay-io-auth-error';
 
 async function getTimestamp(
   config: LookupUpdateConfig,
@@ -704,19 +705,23 @@ export async function lookupUpdates(
               getDigestConfig,
               update.newValue,
             ))!;
-          } catch (QuayIOAuthError) {
-            update.newDigest = null!;
+          } catch (error) {
+            if (error instanceof QuayIOAuthError) {
+              update.newDigest = null!;
 
-            logger.debug(
-              {
-                packageName: config.packageName,
-                currentValue: config.currentValue,
-                datasource: config.datasource,
-                newValue: update.newValue,
-                bucket: update.bucket,
-              },
-              'Caught QuayIOAuthError, update.newDigest should be null, but not cached',
-            );
+              logger.debug(
+                {
+                  packageName: config.packageName,
+                  currentValue: config.currentValue,
+                  datasource: config.datasource,
+                  newValue: update.newValue,
+                  bucket: update.bucket,
+                },
+                'Caught QuayIOAuthError, update.newDigest should be null, but not cached',
+              );
+            } else {
+              throw error;
+            }
           }
 
           if (update.newDigest === undefined || update.newDigest === null) {

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -24,6 +24,7 @@ import { getRangeStrategy } from '../../../../modules/manager';
 import * as allVersioning from '../../../../modules/versioning';
 import { id as dockerVersioningId } from '../../../../modules/versioning/docker';
 import { ExternalHostError } from '../../../../types/errors/external-host-error';
+import { QuayIOAuthError } from '../../../../types/errors/quay-io-auth-error';
 import { assignKeys } from '../../../../util/assign-keys';
 import { getElapsedDays } from '../../../../util/date';
 import { applyPackageRules } from '../../../../util/package-rules';
@@ -43,7 +44,6 @@ import {
   addReplacementUpdateIfValid,
   isReplacementRulesConfigured,
 } from './utils';
-import { QuayIOAuthError } from '../../../../types/errors/quay-io-auth-error';
 
 async function getTimestamp(
   config: LookupUpdateConfig,

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -699,10 +699,25 @@ export async function lookupUpdates(
             );
           }
 
-          update.newDigest ??= (await getDigest(
-            getDigestConfig,
-            update.newValue,
-          ))!;
+          try {
+            update.newDigest ??= (await getDigest(
+              getDigestConfig,
+              update.newValue,
+            ))!;
+          } catch (QuayIOAuthError) {
+            update.newDigest = null!;
+
+            logger.debug(
+              {
+                packageName: config.packageName,
+                currentValue: config.currentValue,
+                datasource: config.datasource,
+                newValue: update.newValue,
+                bucket: update.bucket,
+              },
+              'Caught QuayIOAuthError, update.newDigest should be null, but not cached',
+            );
+          }
 
           if (update.newDigest === undefined || update.newDigest === null) {
             logger.debug(


### PR DESCRIPTION
Ref: KONFLUX-10709

# Old behaviour

- Process **A** calls the following chain of methods:
    - `getDigest`
        - `getImageArchitecture` - `''` for Tekton tasks, but that is now handled correctly
            - `getManifestResponse` (HEAD)
                - `getAuthHeaders`
                    - if there's a `hostRules` rule for a domain with incorrect username+password or token
                        - `return null`
- `null` is propagated `getAuthHeaders` -> `getManifestResponse` -> in `getDigest`, `manifestResponse === null` -> `newDigest` becomes `null`
- The `null` value **is cached**
- Process **B** starts and gets to the call point of `getDigest`, retrieving `null` from the cache
    - because the cache key doesn't use the user repository name

# New behaviour

- Process **A** calls the following chain of methods:
    - `getDigest`
        - `getImageArchitecture` - `''` for Tekton tasks, but that is now handled correctly
            - `getManifestResponse` (HEAD)
                - `getAuthHeaders`
                    - if there's a `hostRules` rule for a domain with incorrect username+password or token
                        - `throw new QuayIOAuthError`
- `QuayIOAuthError` is propagated `getAuthHeaders` -> `getManifestResponse` -> `getDigest` -> `lookupUpdates`, where we explicitly set `newDigest` to `null` and log that the exception happened
- The `null` value **is now not cached** 
- Process **B** starts and gets to the call point of `getDigest`, the cache is unpopulated, thus calling `getDigest` (and the whole chain) again, but with either working credentials or no credentials at all

# How this affects repositories with incorrect quay.io credentials


- _Good_ repos that were poisoned by _bad_ repos will work deterministically,
- but _bad_ repos will now depend on the cache populated by _good_ repos
  -  if the cache is unpopulated, they will receive warnings "Could not determine new digest for update"

in short, the warnings will move from the _good_ repos to the _bad_ repos. This also should not create more support work for us, rather the opposite - we'll be able to navigate users to the problematic credential setups rather than this bug happening for everyone.