### PR TITLE
Clean up debug logging

### DIFF
--- a/lib/modules/datasource/docker/index.ts
+++ b/lib/modules/datasource/docker/index.ts
@@ -131,28 +131,6 @@ export class DockerDatasource extends Datasource {
         cacheProvider: memCacheProvider,
       });
 
-      if (manifestResponse) {
-        logger.debug(
-          {
-            registryHost,
-            dockerRepository,
-            tag,
-            mode,
-            headers: manifestResponse.headers,
-          },
-          'Got manifest response from getManifestResponse() call.',
-        );
-      } else {
-        logger.debug(
-          {
-            registryHost,
-            dockerRepository,
-            tag,
-            mode,
-          },
-          'this.http[mode] returned null?',
-        );
-      }
       return manifestResponse;
     } catch (err) /* istanbul ignore next */ {
       if (err instanceof QuayIOAuthError) {
@@ -933,15 +911,6 @@ export class DockerDatasource extends Datasource {
         );
       }
 
-      logger.debug(
-        {
-          registryHost,
-          dockerRepository,
-          currentDigest,
-        },
-        `getImageArchitecture returned ${architecture === '' ? 'EMPTY STRING' : (architecture ?? 'null')}`,
-      );
-
       let manifestResponse: HttpResponse | null = null;
       if (!architecture) {
         manifestResponse = await this.getManifestResponse(
@@ -951,15 +920,6 @@ export class DockerDatasource extends Datasource {
           'head',
         );
 
-        logger.debug(
-          {
-            registryHost,
-            dockerRepository,
-            newTag,
-          },
-          `Does manifestResponse have docker-content-digest? ${manifestResponse && hasKey('docker-content-digest', manifestResponse.headers)}`,
-        );
-
         if (
           manifestResponse &&
           hasKey('docker-content-digest', manifestResponse.headers)
@@ -967,20 +927,8 @@ export class DockerDatasource extends Datasource {
           digest =
             (manifestResponse.headers['docker-content-digest'] as string) ||
             null;
-
-          if (digest === null) {
-            logger.debug(
-              { registryHost, dockerRepository, newTag, packageName },
-              `No digest found in manifest response headers for package ${packageName} in getDigest() call.`,
-            );
-          }
         }
       }
-
-      logger.debug(
-        { registryHost, dockerRepository },
-        `Architecture checks: isNonEmptyString? ${isNonEmptyString(architecture)}, doesn't have docker-content-digest? ${manifestResponse && !hasKey('docker-content-digest', manifestResponse.headers)}`,
-      );
 
       if (
         isNonEmptyString(architecture) ||

--- a/lib/workers/repository/process/lookup/index.ts
+++ b/lib/workers/repository/process/lookup/index.ts
@@ -683,28 +683,11 @@ export async function lookupUpdates(
           }
 
           // TODO #22198
-          update.newDigest ??= dependency?.releases.find(
-            (r) => r.version === update.newValue,
-          )?.newDigest;
-
-          if (update.newDigest === undefined || update.newDigest === null) {
-            logger.debug(
-              {
-                packageName: config.packageName,
-                currentValue: config.currentValue,
-                datasource: config.datasource,
-                newValue: update.newValue,
-                bucket: update.bucket,
-              },
-              'update.newDigest is undefined or null, releases did not have a digest, fetching digest from getDigest.',
-            );
-          }
-
           try {
-            update.newDigest ??= (await getDigest(
-              getDigestConfig,
-              update.newValue,
-            ))!;
+            update.newDigest ??=
+              dependency?.releases.find((r) => r.version === update.newValue)
+                ?.newDigest ??
+              (await getDigest(getDigestConfig, update.newValue))!;
           } catch (error) {
             if (error instanceof QuayIOAuthError) {
               update.newDigest = null!;
@@ -722,31 +705,6 @@ export async function lookupUpdates(
             } else {
               throw error;
             }
-          }
-
-          if (update.newDigest === undefined || update.newDigest === null) {
-            logger.debug(
-              {
-                packageName: config.packageName,
-                currentValue: config.currentValue,
-                datasource: config.datasource,
-                newValue: update.newValue,
-                bucket: update.bucket,
-              },
-              'update.newDigest is still undefined or null, getDigest returned undefined or null.',
-            );
-          } else {
-            logger.debug(
-              {
-                packageName: config.packageName,
-                currentValue: config.currentValue,
-                datasource: config.datasource,
-                newValue: update.newValue,
-                bucket: update.bucket,
-                newDigest: update.newDigest,
-              },
-              'update.newDigest is defined, getDigest returned a digest.',
-            );
           }
 
           // If the digest could not be determined, report this as otherwise the


### PR DESCRIPTION
This PR removes most of the debugging logging introduced while debugging KONFLUX-10709. Some logging is intentionally left because the previous level of logging in Renovate wasn't sufficient in certain places.