### PR TITLE
Resolve confusion with multiple lockfile updates with RPM lockfiles

### DIFF
--- a/lib/workers/repository/process/rpm-vuln-branches.spec.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.spec.ts
@@ -173,6 +173,57 @@ describe('workers/repository/process/rpm-vuln-branches', () => {
     expect(vulnBranch.rpmVulnerabilityAutomerge).toBe('HIGH');
   });
 
+  it('keeps original prTitle when there is a single rpm-lockfile upgrade', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const branches = [baseBranch];
+
+    const [resultBranches] = createRPMLockFileVulnerabilityBranches(
+      branches,
+      config,
+    );
+
+    const vulnBranch = resultBranches[0];
+    expect(vulnBranch.prTitle).toBe(
+      'chore: rpm lockfile maintenance [SECURITY]',
+    );
+  });
+
+  it('overrides prTitle when there are multiple upgrades', () => {
+    const config: RenovateConfig = { rpmVulnerabilityAlerts: true } as any;
+    const multiUpgradeBranch: BranchConfig = {
+      ...baseBranch,
+      upgrades: [
+        {
+          branchName: 'rpm-lockfile-maintenance',
+          branchTopic: 'topic',
+          manager: 'rpm-lockfile',
+          schedule: ['after 1am'],
+          commitMessageSuffix: '',
+          isVulnerabilityAlert: false,
+          vulnerabilityFixStrategy: undefined,
+        },
+        {
+          branchName: 'rpm-lockfile-maintenance',
+          branchTopic: 'topic',
+          manager: 'npm',
+          schedule: ['after 1am'],
+          commitMessageSuffix: '',
+          isVulnerabilityAlert: false,
+          vulnerabilityFixStrategy: undefined,
+        },
+      ],
+    };
+    const branches = [multiUpgradeBranch];
+
+    const [resultBranches] = createRPMLockFileVulnerabilityBranches(
+      branches,
+      config,
+    );
+
+    const vulnBranch = resultBranches[0];
+    expect(vulnBranch.prTitle).toBe('Lock file maintenance [SECURITY]');
+  });
+
   it('sets rpmVulnerabilityAutomerge to undefined when config is undefined', () => {
     const config: RenovateConfig = {
       rpmVulnerabilityAlerts: true,

--- a/lib/workers/repository/process/rpm-vuln-branches.ts
+++ b/lib/workers/repository/process/rpm-vuln-branches.ts
@@ -45,6 +45,18 @@ export function createRPMLockFileVulnerabilityBranches(
       upgrade.vulnerabilityFixStrategy = 'lowest';
     }
 
+    if (
+      copiedBranch.upgrades.length === 1 &&
+      copiedBranch.upgrades[0].manager === 'rpm-lockfile'
+    ) {
+      // There is only one update to RPM lockfile,
+      // so the config stays the same and the PR will be title 'Refresh RPM lockfiles'
+    } else {
+      // There is more than one lockfile update in the repo,
+      // so to make it less confusing, we choose the original PR title for lock file updates
+      copiedBranch.prTitle = 'Lock file maintenance [SECURITY]';
+    }
+
     // Add the vulnerability branch BEFORE the original branch
     const originalBranchIndex = resultBranches.findIndex(
       (resultBranch) => resultBranch.branchName === branch.branchName,


### PR DESCRIPTION
If there is more than one lock file in a repo **and** one or more RPM lock files, then any lock file maintenance PR would be named `Refresh RPM lockfiles`. This is confusing users, but the grouping itself is _not_ a bug. This PR changes the logic so that:

- If there's only a single lock file update from the `rpm-lockfile` manager, the PR will be titled `Refresh RPM lockfiles`
- If there is more than one lock file, the PR will be titled `Lock file maintenance` (the original Renovate behaviour)

Hopefully this reduces confusion.