### PR TITLE
fix: Stop Renovate from pruning branches not belonging to current base

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -221,5 +221,73 @@ describe('workers/repository/finalize/prune', () => {
       expect(scm.deleteBranch).toHaveBeenCalledTimes(0);
       expect(platform.updatePr).toHaveBeenCalledTimes(0);
     });
+
+    it('with parallelRunPruneStaleBranches and empty branchList uses config base and only prunes branches for that base', async () => {
+      config.parallelRunPruneStaleBranches = true;
+      config.branchList = [];
+      config.baseBranches = ['release'];
+      config.defaultBranch = 'main';
+      const mainBranch = 'renovate/konflux/main/gomod-update';
+      const releaseBranch = 'renovate/konflux/release/some-branch';
+      git.getBranchList.mockReturnValueOnce([mainBranch, releaseBranch]);
+      platform.findPr.mockResolvedValueOnce(
+        partial<Pr>({ title: 'Release PR' }),
+      );
+      scm.isBranchModified.mockResolvedValueOnce(false);
+
+      await cleanup.pruneStaleBranches(config, config.branchList);
+
+      expect(git.getBranchList).toHaveBeenCalledTimes(1);
+      // Only release branch should be pruned; main's branch must not be touched
+      expect(platform.findPr).toHaveBeenCalledTimes(1);
+      expect(platform.findPr).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: releaseBranch,
+          state: 'open',
+        }),
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledTimes(1);
+      expect(scm.deleteBranch).toHaveBeenCalledWith(releaseBranch);
+      expect(platform.updatePr).toHaveBeenCalledTimes(1);
+    });
+
+    it('with parallelRunPruneStaleBranches and empty branchList and no base in config returns without pruning', async () => {
+      config.parallelRunPruneStaleBranches = true;
+      config.branchList = [];
+      delete config.baseBranches;
+      delete config.baseBranch;
+      git.getBranchList.mockReturnValueOnce([
+        'renovate/konflux/main/gomod-update',
+        'renovate/konflux/release/some-branch',
+      ]);
+
+      await cleanup.pruneStaleBranches(config, config.branchList);
+
+      expect(git.getBranchList).toHaveBeenCalledTimes(1);
+      expect(platform.findPr).not.toHaveBeenCalled();
+      expect(scm.deleteBranch).not.toHaveBeenCalled();
+      expect(platform.updatePr).not.toHaveBeenCalled();
+    });
+
+    it('with parallelRunPruneStaleBranches and no baseBranches derives base from first branchList entry', async () => {
+      config.parallelRunPruneStaleBranches = true;
+      delete config.baseBranches;
+      config.defaultBranch = 'main';
+      const kept = 'renovate/konflux/release/kept';
+      const stale = 'renovate/konflux/release/stale';
+      const otherBase = 'renovate/konflux/main/other';
+      config.branchList = [kept];
+      git.getBranchList.mockReturnValueOnce([kept, stale, otherBase]);
+      platform.findPr.mockResolvedValueOnce(partial<Pr>({ title: 'stale PR' }));
+      scm.isBranchModified.mockResolvedValueOnce(false);
+
+      await cleanup.pruneStaleBranches(config, config.branchList);
+
+      expect(platform.findPr).toHaveBeenCalledTimes(1);
+      expect(platform.findPr).toHaveBeenCalledWith(
+        expect.objectContaining({ branchName: stale, state: 'open' }),
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledExactlyOnceWith(stale);
+    });
   });
 });

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -167,22 +167,30 @@ export async function pruneStaleBranches(
 
   if (config.parallelRunPruneStaleBranches) {
     logger.debug('Filtering stale branches to only belong to the base branch');
-    const baseBranch = branchList?.[0]?.split('/')[2] ?? null;
-    if (typeof baseBranch === 'string') {
-      renovateBranches = renovateBranches.filter((branchName) => {
-        try {
-          const parts = branchName.split('/');
-          if (parts.length >= 3) {
-            const branchBaseName = parts[2];
-            return branchBaseName === baseBranch;
-          }
-          return true;
-        } catch {
-          // If unable to parse, keep it
-          return true;
-        }
-      });
+
+    let baseBranch = '';
+    if (config.baseBranches && config.baseBranches.length > 0) {
+      // for parallel run, baseBranches is set (through baseBranchPatterns)
+      // and it should only contain a single base branch
+      baseBranch = config.baseBranches[0];
+    } else {
+      // if no base branches are configured, use the first branch
+      // in the branch list, split by '/' and use the third segment
+      // as the base branch (following default pattern for MintMaker:
+      // "konflux/mintmaker/base-branch/..." or "konflux/references/base-branch")
+      baseBranch = branchList?.[0]?.split('/')[2] ?? '';
     }
+
+    if (!baseBranch) {
+      logger.debug('No base branch found for this run - skipping pruning');
+      return;
+    }
+
+    logger.debug(`Base branch for pruning: ${baseBranch}`);
+
+    renovateBranches = renovateBranches.filter((branchName) =>
+      branchName.split('/').includes(baseBranch),
+    );
   }
 
   logger.debug(


### PR DESCRIPTION
Jira: [CWFHEALTH-4720](https://redhat.atlassian.net/browse/CWFHEALTH-4720)

When branchList was empty, pruning wasn’t scoped by base and Renovate pruned all branches created by Renovate in other runs (and could close PRs for other bases).

Add safety net, if there was no branch created on this Renovate run (i.e. for this base branch):
- Look for base branch from config
- If no base branch is found, do not prune any branches

This commit also adds unit tests for this behavior.

Assisted-by: Cursor