### PR TITLE
Fix redis impl missing variable

### DIFF
--- a/lib/util/cache/package/redis.ts
+++ b/lib/util/cache/package/redis.ts
@@ -4,7 +4,6 @@ import { createClient, createCluster } from 'redis';
 import { logger } from '../../../logger/index.ts';
 import { compressToBase64, decompressFromBase64 } from '../../compress.ts';
 import { regEx } from '../../regex.ts';
-import { resolveTtlValues } from './ttl.ts';
 import type { PackageCacheNamespace } from './types.ts';
 
 let client:
@@ -74,19 +73,13 @@ export async function set(
   value: unknown,
   hardTtlMinutes = 5,
 ): Promise<void> {
-  const ttlValues = resolveTtlValues(namespace, ttlMinutes);
-  const effectiveTtlMinutes = Math.max(
-    ttlMinutes,
-    ttlValues.softTtlMinutes ?? 0,
-  );
-
   logger.trace(
-    { rprefix, namespace, key, effectiveTtlMinutes },
+    { rprefix, namespace, key, hardTtlMinutes },
     'Saving cached value',
   );
 
   // Redis requires TTL to be integer, not float
-  const redisTTL = Math.floor(effectiveTtlMinutes * 60);
+  const redisTTL = Math.floor(hardTtlMinutes * 60);
 
   try {
     await client?.set(
@@ -94,7 +87,7 @@ export async function set(
       JSON.stringify({
         compress: true,
         value: await compressToBase64(JSON.stringify(value)),
-        expiry: DateTime.local().plus({ minutes: effectiveTtlMinutes }),
+        expiry: DateTime.local().plus({ minutes: hardTtlMinutes }),
       }),
       { EX: redisTTL },
     );


### PR DESCRIPTION
This fixes `ReferenceError: ttlMinutes is not defined` and subsequent `Failed to look up ... package ...` when the cache is enabled.