### PR TITLE
fix: special case in parallelPruneStaleBranches

### DIFF
--- a/lib/workers/repository/finalize/prune.spec.ts
+++ b/lib/workers/repository/finalize/prune.spec.ts
@@ -289,5 +289,36 @@ describe('workers/repository/finalize/prune', () => {
       );
       expect(scm.deleteBranch).toHaveBeenCalledExactlyOnceWith(stale);
     });
+
+    it('with parallelRunPruneStaleBranches prunes branch with duplicated base segment', async () => {
+      config.parallelRunPruneStaleBranches = true;
+      config.baseBranches = ['main'];
+      config.defaultBranch = 'main';
+      config.branchPrefix = 'konflux/mintmaker/';
+      config.branchList = [];
+      const duplicatedBaseBranch = 'konflux/mintmaker/main-main/dep-1.x';
+      const otherBaseBranch = 'konflux/mintmaker/release-release/dep-1.x';
+      git.getBranchList.mockReturnValueOnce([
+        duplicatedBaseBranch,
+        otherBaseBranch,
+      ]);
+      platform.findPr.mockResolvedValueOnce(partial<Pr>({ title: 'main PR' }));
+      scm.isBranchModified.mockResolvedValueOnce(false);
+
+      await cleanup.pruneStaleBranches(config, config.branchList);
+
+      expect(platform.findPr).toHaveBeenCalledTimes(1);
+      expect(platform.findPr).toHaveBeenCalledWith(
+        expect.objectContaining({
+          branchName: duplicatedBaseBranch,
+          state: 'open',
+          targetBranch: 'main',
+        }),
+      );
+      expect(scm.deleteBranch).toHaveBeenCalledExactlyOnceWith(
+        duplicatedBaseBranch,
+      );
+      expect(platform.updatePr).toHaveBeenCalledTimes(1);
+    });
   });
 });

--- a/lib/workers/repository/finalize/prune.ts
+++ b/lib/workers/repository/finalize/prune.ts
@@ -188,9 +188,16 @@ export async function pruneStaleBranches(
 
     logger.debug(`Base branch for pruning: ${baseBranch}`);
 
-    renovateBranches = renovateBranches.filter((branchName) =>
-      branchName.split('/').includes(baseBranch),
-    );
+    // look for a segment of branch name matching the base branch or the base branch duplicated
+    // this duplication happens when branchTopic is set to the base branch and at the same time
+    // the baseBranchPatterns includes more than one branch
+    const baseBranchDuplicated = `${baseBranch}-${baseBranch}`;
+    renovateBranches = renovateBranches.filter((branchName) => {
+      const segments = branchName.split('/');
+      return segments.some(
+        (segment) => segment === baseBranch || segment === baseBranchDuplicated,
+      );
+    });
   }
 
   logger.debug(


### PR DESCRIPTION
- Now treating both the base segment (main) and duplicated base segment (main-main) as valid matches when filtering branches in parallel mode.
- Added a test in prune.spec.ts to ensure duplicated-base branches are selected and pruned.