### PR TITLE
Pass DNF variables to refresh-rpm-lockfiles script

### DIFF
--- a/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
+++ b/lib/workers/repository/update/branch/execute-post-upgrade-commands.ts
@@ -137,7 +137,17 @@ export async function postUpgradeCommandsExecutor(
               ),
 
               cwd: workingDir,
-              extraEnv: getGitEnvironmentVariables(),
+              extraEnv: {
+                ...getGitEnvironmentVariables(),
+                ...(compiledCmd.startsWith('refresh-rpm-lockfiles') && {
+                  DNF_VAR_SSL_CLIENT_KEY: process.env.DNF_VAR_SSL_CLIENT_KEY,
+                  DNF_VAR_SSL_CLIENT_CERT: process.env.DNF_VAR_SSL_CLIENT_CERT,
+                  DNF_VAR_SSL_AUTH_CLIENT_KEY:
+                    process.env.DNF_VAR_SSL_AUTH_CLIENT_KEY,
+                  DNF_VAR_SSL_AUTH_CLIENT_CERT:
+                    process.env.DNF_VAR_SSL_AUTH_CLIENT_CERT,
+                }),
+              },
             };
             if (dataFilePath) {
               execOpts.env = {


### PR DESCRIPTION
Ok I realise this is an ugly hack, but Renovate doesn't pass any environment variables (except git auth vars) to postUpgradeTasks... this should only be temporary, until we figure how to extract the RPM lockfile functionality out of Renovate completely.